### PR TITLE
Update the 'gen' tactic to generalize in reverse order

### DIFF
--- a/coq/Tactics.v
+++ b/coq/Tactics.v
@@ -107,26 +107,26 @@ Tactic Notation "gen" constr(e1) :=
   generalize dependent e1.
 
 Tactic Notation "gen" constr(e1) constr(e2) :=
-  generalize dependent e1;
-  generalize dependent e2.
+  generalize dependent e2;
+  generalize dependent e1.
 
 Tactic Notation "gen" constr(e1) constr(e2) constr(e3) :=
-  generalize dependent e1;
+  generalize dependent e3;
   generalize dependent e2;
-  generalize dependent e3.
+  generalize dependent e1.
 
 Tactic Notation "gen" constr(e1) constr(e2) constr(e3) constr(e4) :=
-  generalize dependent e1;
-  generalize dependent e2;
+  generalize dependent e4;
   generalize dependent e3;
-  generalize dependent e4.
+  generalize dependent e2;
+  generalize dependent e1.
 
 Tactic Notation "gen" constr(e1) constr(e2) constr(e3) constr(e4) constr(e5) :=
-  generalize dependent e1;
-  generalize dependent e2;
-  generalize dependent e3;
+  generalize dependent e5;
   generalize dependent e4;
-  generalize dependent e5.
+  generalize dependent e3;
+  generalize dependent e2;
+  generalize dependent e1.
 
 (* This is like the `inversion` tactic, but leaves less junk around. *)
 


### PR DESCRIPTION
Update the `gen` tactic to generalize in reverse order. That way the resulting goal will have the premises in the intended order.