### PR TITLE
Export the 'Name' module

### DIFF
--- a/coq/STLC/FreeVar.v
+++ b/coq/STLC/FreeVar.v
@@ -9,8 +9,6 @@
 Require Import Main.STLC.Name.
 Require Import Main.STLC.Syntax.
 
-Import Name.
-
 Inductive freeVar : term -> name -> Prop :=
 | fIf1 :
   forall e1 e2 e3 x,

--- a/coq/STLC/Name.v
+++ b/coq/STLC/Name.v
@@ -28,3 +28,5 @@ Module Name : NameSig.
   Hint Resolve nameEq.
 
 End Name.
+
+Export Name.

--- a/coq/STLC/Preservation.v
+++ b/coq/STLC/Preservation.v
@@ -13,8 +13,6 @@ Require Import Main.STLC.Substitution.
 Require Import Main.STLC.Typing.
 Require Import Main.Tactics.
 
-Import Name.
-
 Lemma contextInvariance :
   forall c1 c2 e t,
   hasType c1 e t ->

--- a/coq/STLC/Substitution.v
+++ b/coq/STLC/Substitution.v
@@ -9,8 +9,6 @@
 Require Import Main.STLC.Name.
 Require Import Main.STLC.Syntax.
 
-Import Name.
-
 Fixpoint sub e1 x1 e2 :=
   match e1 with
   | eTrue => e1

--- a/coq/STLC/Syntax.v
+++ b/coq/STLC/Syntax.v
@@ -8,8 +8,6 @@
 
 Require Import Main.STLC.Name.
 
-Import Name.
-
 Inductive term : Set :=
 | eTrue : term
 | eFalse : term

--- a/coq/STLC/Typing.v
+++ b/coq/STLC/Typing.v
@@ -9,8 +9,6 @@
 Require Import Main.STLC.Name.
 Require Import Main.STLC.Syntax.
 
-Import Name.
-
 Inductive context :=
 | cEmpty : context
 | cExtend : context -> name -> type -> context.


### PR DESCRIPTION
Export the `Name` module so we don't have to import it everywhere.