### PR TITLE
Use shorter names for modules in the prelude

### DIFF
--- a/coq/CategoryTheory/Cat.v
+++ b/coq/CategoryTheory/Cat.v
@@ -6,10 +6,10 @@
 (******************************************************************)
 (******************************************************************)
 
-Require Import Coq.Logic.ProofIrrelevance.
 Require Import Main.CategoryTheory.Category.
 Require Import Main.CategoryTheory.Functor.
 Require Import Main.Tactics.
+Require Import ProofIrrelevance.
 
 Hint Resolve proof_irrelevance.
 

--- a/coq/CategoryTheory/Maybe.v
+++ b/coq/CategoryTheory/Maybe.v
@@ -6,7 +6,7 @@
 (*******************************************)
 (*******************************************)
 
-Require Import Coq.Logic.FunctionalExtensionality.
+Require Import FunctionalExtensionality.
 Require Import Main.CategoryTheory.Functor.
 Require Import Main.CategoryTheory.Monad.
 Require Import Main.CategoryTheory.NaturalTransformation.


### PR DESCRIPTION
Use shorter names for modules in the prelude.