### PR TITLE
Use 'Theorem' instead of 'Lemma' everywhere

### DIFF
--- a/coq/Intro.v
+++ b/coq/Intro.v
@@ -120,7 +120,7 @@ Inductive odd : nat -> Prop :=
   the same time.
 *)
 
-Lemma doubleInd :
+Theorem doubleInd :
   forall P : nat -> Prop,
   P zero ->
   P (succ zero) ->

--- a/coq/Reflection.v
+++ b/coq/Reflection.v
@@ -56,7 +56,7 @@ Fixpoint isEven n :=
 
 (* A proof that (even n) is reflected in (isEven n) *)
 
-Lemma evenInd :
+Theorem evenInd :
   forall P : nat -> Prop,
   P 0 ->
   P 1 ->
@@ -90,7 +90,7 @@ Qed.
 
 (* A proof by reflection of (even 1000) *)
 
-Lemma evenOneThousand : even 1000.
+Theorem evenOneThousand : even 1000.
 Proof.
   reflect (evenRefl 1000).
 Qed.

--- a/coq/STLC/Preservation.v
+++ b/coq/STLC/Preservation.v
@@ -24,7 +24,7 @@ Qed.
 
 Hint Resolve typingJudgmentClosed.
 
-Lemma contextInvariance :
+Theorem contextInvariance :
   forall c1 c2 e t,
   hasType c1 e t ->
   (forall x, freeVar e x -> lookupVar c1 x = lookupVar c2 x) ->


### PR DESCRIPTION
Use `Theorem` instead of `Lemma` everywhere. That way I don't have to think about which one to use.