### PR TITLE
Rename lookupVar to lookup in the STLC presentation and convert an eapply into apply

### DIFF
--- a/coq/STLC/Preservation.v
+++ b/coq/STLC/Preservation.v
@@ -17,7 +17,7 @@ Theorem typingJudgmentClosed :
   forall c e x t1,
   hasType c e t1 ->
   freeVar e x ->
-  exists t2, lookupVar c x = Some t2.
+  exists t2, lookup c x = Some t2.
 Proof.
   clean. induction H; invert H0; eMagic.
 Qed.
@@ -27,7 +27,7 @@ Hint Resolve typingJudgmentClosed.
 Theorem contextInvariance :
   forall c1 c2 e t,
   hasType c1 e t ->
-  (forall x, freeVar e x -> lookupVar c1 x = lookupVar c2 x) ->
+  (forall x, freeVar e x -> lookup c1 x = lookup c2 x) ->
   hasType c2 e t.
 Proof.
   clean. gen c2. induction H; magic; clean.
@@ -46,7 +46,7 @@ Theorem substitutionPreservesTyping :
 Proof.
   clean. gen c t2. induction e2; clean; invert H; eMagic; clean.
   - destruct (nameEq x n); destruct (nameEq n x); magic.
-    eapply contextInvariance with (c1 := cEmpty); magic.
+    apply contextInvariance with (c1 := cEmpty); magic.
     clean. fact (typingJudgmentClosed cEmpty e1 x0 t1). magic.
   - destruct (nameEq x n); apply htAbs.
     + apply contextInvariance with (c1 := cExtend (cExtend c n t1) n t); magic.

--- a/coq/STLC/Typing.v
+++ b/coq/STLC/Typing.v
@@ -13,10 +13,10 @@ Inductive context :=
 | cEmpty : context
 | cExtend : context -> name -> type -> context.
 
-Fixpoint lookupVar c1 x1 :=
+Fixpoint lookup c1 x1 :=
   match c1 with
   | cEmpty => None
-  | cExtend c2 x2 t => if nameEq x1 x2 then Some t else lookupVar c2 x1
+  | cExtend c2 x2 t => if nameEq x1 x2 then Some t else lookup c2 x1
   end.
 
 Inductive hasType : context -> term -> type -> Prop :=
@@ -34,7 +34,7 @@ Inductive hasType : context -> term -> type -> Prop :=
   hasType c (eIf e1 e2 e3) t
 | htVar :
   forall c t x,
-  lookupVar c x = Some t ->
+  lookup c x = Some t ->
   hasType c (eVar x) t
 | htAbs :
   forall c e t1 t2 x,


### PR DESCRIPTION
Rename `lookupVar` to `lookup` in the STLC presentation (to more closely match the System F version) and convert an `eapply` into `apply`.