### PR TITLE
Prove that the dual category construction is an involution

### DIFF
--- a/coq/CategoryTheory/Category.v
+++ b/coq/CategoryTheory/Category.v
@@ -7,6 +7,9 @@
 (************************)
 
 Require Import Main.Tactics.
+Require Import ProofIrrelevance.
+
+Hint Resolve proof_irrelevance.
 
 Set Universe Polymorphism.
 
@@ -41,3 +44,16 @@ Proof.
     _ _ _
   ); magic.
 Defined.
+
+(* The following proof depends on proof irrelevance. *)
+
+Theorem oppositeInvolution :
+  forall C, oppositeCategory (oppositeCategory C) = C.
+Proof.
+  unfold oppositeCategory.
+  clean.
+  destruct C.
+  magic.
+Qed.
+
+Hint Resolve oppositeInvolution.


### PR DESCRIPTION
Prove that the dual category construction is an involution. The proof depends on [proof irrelevance](https://coq.inria.fr/library/Coq.Logic.ProofIrrelevance.html), which is not implied by the metatheory of Coq.