### PR TITLE
Use proof irrelevance for the whole category theory development

### DIFF
--- a/coq/CategoryTheory/Category.v
+++ b/coq/CategoryTheory/Category.v
@@ -45,8 +45,6 @@ Proof.
   ); magic.
 Defined.
 
-(* The following proof depends on proof irrelevance. *)
-
 Theorem oppositeInvolution :
   forall C, oppositeCategory (oppositeCategory C) = C.
 Proof.

--- a/coq/CategoryTheory/Examples/Cat.v
+++ b/coq/CategoryTheory/Examples/Cat.v
@@ -9,9 +9,6 @@
 Require Import Main.CategoryTheory.Category.
 Require Import Main.CategoryTheory.Functor.
 Require Import Main.Tactics.
-Require Import ProofIrrelevance.
-
-Hint Resolve proof_irrelevance.
 
 Definition catCategory : category.
 Proof.


### PR DESCRIPTION
Use proof irrelevance for the whole category theory development.