### PR TITLE
Don't add axioms to the global hints database

### DIFF
--- a/coq/CategoryTheory/Category.v
+++ b/coq/CategoryTheory/Category.v
@@ -9,8 +9,6 @@
 Require Import Main.Tactics.
 Require Import ProofIrrelevance.
 
-Hint Resolve proof_irrelevance.
-
 Set Universe Polymorphism.
 
 (* Metavariables for categories: C, D, E *)
@@ -45,13 +43,17 @@ Proof.
   ); magic.
 Defined.
 
-Theorem oppositeInvolution :
-  forall C, oppositeCategory (oppositeCategory C) = C.
-Proof.
-  unfold oppositeCategory.
-  clean.
-  destruct C.
-  magic.
-Qed.
+Section ProofIrrelevance.
+  Hint Resolve proof_irrelevance.
+
+  Theorem oppositeInvolution :
+    forall C, oppositeCategory (oppositeCategory C) = C.
+  Proof.
+    unfold oppositeCategory.
+    clean.
+    destruct C.
+    magic.
+  Qed.
+End ProofIrrelevance.
 
 Hint Resolve oppositeInvolution.

--- a/coq/CategoryTheory/Examples/Cat.v
+++ b/coq/CategoryTheory/Examples/Cat.v
@@ -9,15 +9,20 @@
 Require Import Main.CategoryTheory.Category.
 Require Import Main.CategoryTheory.Functor.
 Require Import Main.Tactics.
+Require Import ProofIrrelevance.
 
-Definition catCategory : category.
-Proof.
-  refine (
-    newCategory
-    category
-    (fun x y => @functor x y)
-    (fun x y z => compFunctor)
-    (fun x => idFunctor)
-    _ _ _
-  ); unfold compFunctor; destruct f; magic.
-Defined.
+Section ProofIrrelevance.
+  Hint Resolve proof_irrelevance.
+
+  Definition catCategory : category.
+  Proof.
+    refine (
+      newCategory
+      category
+      (fun x y => @functor x y)
+      (fun x y z => compFunctor)
+      (fun x => idFunctor)
+      _ _ _
+    ); unfold compFunctor; destruct f; magic.
+  Defined.
+End ProofIrrelevance.


### PR DESCRIPTION
Certain results depend on axioms such as proof irrelevance or functional extensionality. We use these axioms where necessary, but we should not add them as hints to the global hints database (so it is clear which results depend on which axioms). This PR uses Coq's "section" mechanism to add such hints locally, such that the hint is no longer available when the section is closed.