### PR TITLE
Prove that coproducts are unique up to isomorphism

### DIFF
--- a/coq/CategoryTheory/Arrow.v
+++ b/coq/CategoryTheory/Arrow.v
@@ -104,7 +104,7 @@ Qed.
 
 Hint Resolve isoImpliesMono.
 
-Theorem opIso :
+Theorem opIsomorphism :
   forall C x y,
   (exists f, @isomorphism C x y f) <->
   (exists f, @isomorphism (oppositeCategory C) x y f).
@@ -112,4 +112,4 @@ Proof.
   unfold isomorphism; split; clean; exists x1; eMagic.
 Qed.
 
-Hint Resolve opIso.
+Hint Resolve opIsomorphism.

--- a/coq/CategoryTheory/Coproduct.v
+++ b/coq/CategoryTheory/Coproduct.v
@@ -8,6 +8,7 @@
 
 Require Import Main.CategoryTheory.Arrow.
 Require Import Main.CategoryTheory.Category.
+Require Import Main.CategoryTheory.Object.
 Require Import Main.CategoryTheory.Product.
 Require Import Main.Tactics.
 
@@ -28,7 +29,7 @@ Definition coproduct
     (qy : arrow C y z),
   universal (fun f => qx = compose C f ix /\ qy = compose C f iy).
 
-Theorem opProductCoproduct :
+Theorem opCoproductProduct :
   forall C x y xy px py,
   @coproduct C x y xy px py <->
   @product (oppositeCategory C) x y xy px py.
@@ -36,4 +37,28 @@ Proof.
   magic.
 Qed.
 
+Hint Resolve opCoproductProduct.
+
+Theorem opProductCoproduct :
+  forall C x y xy px py,
+  @product C x y xy px py <->
+  @coproduct (oppositeCategory C) x y xy px py.
+Proof.
+  magic.
+Qed.
+
 Hint Resolve opProductCoproduct.
+
+Theorem coproductUnique :
+  forall C (x y : object C),
+  uniqueUpToIsomorphism (fun x_y => exists ix iy, coproduct x y x_y ix iy).
+Proof.
+  unfold uniqueUpToIsomorphism.
+  clean.
+  rewrite opCoproductProduct in *.
+  rewrite opIsomorphic.
+  fact (productUnique (oppositeCategory C) x y x0 y0).
+  eMagic.
+Qed.
+
+Hint Resolve coproductUnique.

--- a/coq/CategoryTheory/Object.v
+++ b/coq/CategoryTheory/Object.v
@@ -30,6 +30,14 @@ Definition terminal {C} x :=
   exists f,
   forall (g : arrow C y x), f = g.
 
+Theorem opIsomorphic :
+  forall C x y, @isomorphic C x y <-> @isomorphic (oppositeCategory C) x y.
+Proof.
+  apply opIsomorphism.
+Qed.
+
+Hint Resolve opIsomorphic.
+
 Theorem opInitialTerminal :
   forall C x,
   @initial C x <->
@@ -72,7 +80,7 @@ Proof.
   unfold uniqueUpToIsomorphism.
   clean.
   rewrite opTerminalInitial in *.
-  apply opIso.
+  rewrite opIsomorphic.
   apply initialUnique; magic.
 Qed.
 


### PR DESCRIPTION
Prove that coproducts are unique up to isomorphism. The proof is by duality, using the already-proven result that products are unique up to isomorphism.