### PR TITLE
Reorder the arguments of leftWhisker to make it more intuitive

### DIFF
--- a/coq/CategoryTheory/Monad.v
+++ b/coq/CategoryTheory/Monad.v
@@ -21,10 +21,10 @@ Record monad
   (Mu : @naturalTransformation C C (compFunctor F F) F) :=
 newMonad {
   mAssoc :
-    eta (compNaturalTransformation Mu (leftWhisker F Mu)) =
+    eta (compNaturalTransformation Mu (leftWhisker Mu F)) =
     eta (compNaturalTransformation Mu (rightWhisker F Mu));
   mIdent1 :
-    eta (compNaturalTransformation Mu (leftWhisker F Eta)) =
+    eta (compNaturalTransformation Mu (leftWhisker Eta F)) =
     eta idNaturalTransformation;
   mIdent2 :
     eta (compNaturalTransformation Mu (rightWhisker F Eta)) =

--- a/coq/CategoryTheory/NaturalTransformation.v
+++ b/coq/CategoryTheory/NaturalTransformation.v
@@ -79,8 +79,8 @@ Defined.
 Definition leftWhisker
   {C D E : category}
   {F G : @functor D E}
-  (H : @functor C D)
-  (Eta : @naturalTransformation D E F G) :
+  (Eta : @naturalTransformation D E F G)
+  (H : @functor C D) :
   @naturalTransformation C E (compFunctor F H) (compFunctor G H).
 Proof.
   refine (


### PR DESCRIPTION
Reorder the arguments of leftWhisker to make it more intuitive.