### PR TITLE
Refactor some of the category theory development

### DIFF
--- a/coq/CategoryTheory/Arrow.v
+++ b/coq/CategoryTheory/Arrow.v
@@ -40,8 +40,7 @@ Definition retraction {C x y} (f : arrow C x y) :=
 Definition section {C x y} (f : arrow C x y) :=
   exists g, compose C g f = id C.
 
-Theorem opIsomorphism :
-  forall C x y f,
+Theorem opIsomorphism C x y f :
   @isomorphism C x y f <-> @isomorphism (oppositeCategory C) y x f.
 Proof.
   unfold isomorphism.
@@ -51,8 +50,7 @@ Qed.
 
 Hint Resolve opIsomorphism.
 
-Theorem opMonoEpi :
-  forall C x y f,
+Theorem opMonoEpi C x y f :
   @monomorphism C x y f <-> @epimorphism (oppositeCategory C) y x f.
 Proof.
   magic.
@@ -60,8 +58,7 @@ Qed.
 
 Hint Resolve opMonoEpi.
 
-Theorem opEpiMono :
-  forall C x y f,
+Theorem opEpiMono C x y f :
   @epimorphism C x y f <-> @monomorphism (oppositeCategory C) y x f.
 Proof.
   magic.
@@ -69,8 +66,7 @@ Qed.
 
 Hint Resolve opEpiMono.
 
-Theorem opRetSec :
-  forall C x y f,
+Theorem opRetSec C x y f :
   @retraction C x y f <-> @section (oppositeCategory C) y x f.
 Proof.
   magic.
@@ -78,8 +74,7 @@ Qed.
 
 Hint Resolve opRetSec.
 
-Theorem opSecRet :
-  forall C x y f,
+Theorem opSecRet C x y f :
   @section C x y f <-> @retraction (oppositeCategory C) y x f.
 Proof.
   magic.
@@ -87,8 +82,8 @@ Qed.
 
 Hint Resolve opSecRet.
 
-Theorem rightIdUnique :
-  forall C x, arrowUnique (
+Theorem rightIdUnique C x:
+  arrowUnique (
     fun (f : arrow C x x) => forall y (g : arrow C x y), compose C g f = g
   ).
 Proof.
@@ -101,8 +96,8 @@ Qed.
 
 Hint Resolve rightIdUnique.
 
-Theorem leftIdUnique :
-  forall C x, arrowUnique (
+Theorem leftIdUnique C x:
+  arrowUnique (
     fun (f : arrow C x x) => forall y (g : arrow C y x), compose C f g = g
   ).
 Proof.
@@ -115,7 +110,7 @@ Qed.
 
 Hint Resolve leftIdUnique.
 
-Theorem inverseUnique {C x y} (f : arrow C x y) : arrowUnique (inverse f).
+Theorem inverseUnique C x y (f : arrow C x y) : arrowUnique (inverse f).
 Proof.
   unfold arrowUnique.
   unfold inverse.
@@ -128,7 +123,7 @@ Qed.
 
 Hint Resolve inverseUnique.
 
-Theorem inverseInvolution {C x y} (f h : arrow C x y) (g : arrow C y x) :
+Theorem inverseInvolution C x y (f h : arrow C x y) (g : arrow C y x) :
   inverse f g -> inverse g h -> f = h.
 Proof.
   unfold inverse.
@@ -142,8 +137,7 @@ Qed.
 
 Hint Resolve inverseInvolution.
 
-Theorem isoImpliesEpi :
-  forall C x y f, @isomorphism C x y f -> @epimorphism C x y f.
+Theorem isoImpliesEpi C x y f : @isomorphism C x y f -> @epimorphism C x y f.
 Proof.
   unfold isomorphism.
   unfold epimorphism.
@@ -159,8 +153,7 @@ Qed.
 
 Hint Resolve isoImpliesEpi.
 
-Theorem isoImpliesMono :
-  forall C x y f, @isomorphism C x y f -> @monomorphism C x y f.
+Theorem isoImpliesMono C x y f : @isomorphism C x y f -> @monomorphism C x y f.
 Proof.
   clean.
   rewrite opMonoEpi.
@@ -171,8 +164,7 @@ Qed.
 
 Hint Resolve isoImpliesMono.
 
-Theorem secImpliesMono :
-  forall C x y f, @section C x y f -> @monomorphism C x y f.
+Theorem secImpliesMono C x y f : @section C x y f -> @monomorphism C x y f.
 Proof.
   unfold section.
   unfold monomorphism.
@@ -187,8 +179,7 @@ Qed.
 
 Hint Resolve secImpliesMono.
 
-Theorem retImpliesEpi :
-  forall C x y f, @retraction C x y f -> @epimorphism C x y f.
+Theorem retImpliesEpi C x y f : @retraction C x y f -> @epimorphism C x y f.
 Proof.
   clean.
   rewrite opRetSec in H.
@@ -198,8 +189,7 @@ Qed.
 
 Hint Resolve retImpliesEpi.
 
-Theorem monoRetEquivIso :
-  forall C x y f,
+Theorem monoRetEquivIso C x y f :
   @monomorphism C x y f /\ @retraction C x y f <-> @isomorphism C x y f.
 Proof.
   unfold monomorphism.
@@ -226,8 +216,7 @@ Qed.
 
 Hint Resolve monoRetEquivIso.
 
-Theorem epiSecEquivIso :
-  forall C x y f,
+Theorem epiSecEquivIso C x y f :
   @epimorphism C x y f /\ @section C x y f <-> @isomorphism C x y f.
 Proof.
   clean.

--- a/coq/CategoryTheory/Category.v
+++ b/coq/CategoryTheory/Category.v
@@ -16,14 +16,13 @@ Set Universe Polymorphism.
 Record category := newCategory {
   object : Type; (* Metavariables for objects: w, x, y, z *)
   arrow : object -> object -> Type; (* Metavariables for arrows: f, g, h *)
-  compose : forall {x y z}, arrow y z -> arrow x y -> arrow x z;
-  id : forall {x}, arrow x x;
+  compose {x y z} : arrow y z -> arrow x y -> arrow x z;
+  id {x}: arrow x x;
 
-  cAssoc :
-    forall w x y z (f : arrow w x) (g : arrow x y) (h : arrow y z),
+  cAssoc w x y z (f : arrow w x) (g : arrow x y) (h : arrow y z) :
     compose h (compose g f) = compose (compose h g) f;
-  cIdentLeft : forall x y (f : arrow x y), compose id f = f;
-  cIdentRight : forall x y (f : arrow x y), compose f id = f;
+  cIdentLeft x y (f : arrow x y) : compose id f = f;
+  cIdentRight x y (f : arrow x y) : compose f id = f;
 }.
 
 Hint Resolve cAssoc.
@@ -32,28 +31,43 @@ Hint Rewrite cIdentLeft.
 Hint Resolve cIdentRight.
 Hint Rewrite cIdentRight.
 
-Definition oppositeCategory (C : category) : category.
+Let opCAssoc
+  {C : category}
+  (w x y z : object C)
+  (f : arrow C x w)
+  (g : arrow C y x)
+  (h : arrow C z y)
+: compose C (compose C f g) h = compose C f (compose C g h).
 Proof.
-  refine (newCategory
-    (object C)
-    (fun x y => arrow C y x)
-    (fun {x y z} f g => compose C g f)
-    (fun {x} => id C)
-    _ _ _
-  ); magic.
-Defined.
+  magic.
+Qed.
 
-Section ProofIrrelevance.
-  Hint Resolve proof_irrelevance.
+Let opCIdentLeft {C : category} (x y : object C) (f : arrow C y x) :
+  compose C f (id C) = f.
+Proof.
+  magic.
+Qed.
 
-  Theorem oppositeInvolution :
-    forall C, oppositeCategory (oppositeCategory C) = C.
-  Proof.
-    unfold oppositeCategory.
-    clean.
-    destruct C.
-    magic.
-  Qed.
-End ProofIrrelevance.
+Let opCIdentRight {C : category} (x y : object C) (f : arrow C y x) :
+  compose C (id C) f = f.
+Proof.
+  magic.
+Qed.
+
+Definition oppositeCategory (C : category) : category := newCategory
+  (object C)
+  (fun x y => arrow C y x)
+  (fun {x y z} f g => compose C g f)
+  (fun {x} => id C)
+  opCAssoc
+  opCIdentLeft
+  opCIdentRight.
+
+Theorem oppositeInvolution C : oppositeCategory (oppositeCategory C) = C.
+Proof.
+  unfold oppositeCategory.
+  destruct C.
+  f_equal; apply proof_irrelevance.
+Qed.
 
 Hint Resolve oppositeInvolution.

--- a/coq/CategoryTheory/Coproduct.v
+++ b/coq/CategoryTheory/Coproduct.v
@@ -29,28 +29,23 @@ Definition coproduct
     (qy : arrow C y z),
   universal (fun f => qx = compose C f ix /\ qy = compose C f iy).
 
-Theorem opCoproductProduct :
-  forall C x y xy px py,
-  @coproduct C x y xy px py <->
-  @product (oppositeCategory C) x y xy px py.
+Theorem opCoproductProduct C x y xy px py :
+  @coproduct C x y xy px py <-> @product (oppositeCategory C) x y xy px py.
 Proof.
   magic.
 Qed.
 
 Hint Resolve opCoproductProduct.
 
-Theorem opProductCoproduct :
-  forall C x y xy px py,
-  @product C x y xy px py <->
-  @coproduct (oppositeCategory C) x y xy px py.
+Theorem opProductCoproduct C x y xy px py :
+  @product C x y xy px py <-> @coproduct (oppositeCategory C) x y xy px py.
 Proof.
   magic.
 Qed.
 
 Hint Resolve opProductCoproduct.
 
-Theorem coproductUnique :
-  forall C (x y : object C),
+Theorem coproductUnique C (x y : object C) :
   uniqueUpToIsomorphism (fun x_y => exists ix iy, coproduct x y x_y ix iy).
 Proof.
   unfold uniqueUpToIsomorphism.

--- a/coq/CategoryTheory/Examples/Cat.v
+++ b/coq/CategoryTheory/Examples/Cat.v
@@ -8,21 +8,40 @@
 
 Require Import Main.CategoryTheory.Category.
 Require Import Main.CategoryTheory.Functor.
-Require Import Main.Tactics.
 Require Import ProofIrrelevance.
 
-Section ProofIrrelevance.
-  Hint Resolve proof_irrelevance.
+Let catCAssoc
+  (w x y z : category)
+  (f : @functor w x)
+  (g : @functor x y)
+  (h : @functor y z)
+: compFunctor h (compFunctor g f) = compFunctor (compFunctor h g) f.
+Proof.
+  unfold compFunctor.
+  f_equal; apply proof_irrelevance.
+Qed.
 
-  Definition catCategory : category.
-  Proof.
-    refine (
-      newCategory
-      category
-      (fun x y => @functor x y)
-      (fun x y z => compFunctor)
-      (fun x => idFunctor)
-      _ _ _
-    ); unfold compFunctor; destruct f; magic.
-  Defined.
-End ProofIrrelevance.
+Let catCIdentLeft (x y : category) (f : @functor x y) :
+  compFunctor idFunctor f = f.
+Proof.
+  unfold compFunctor.
+  destruct f.
+  f_equal; apply proof_irrelevance.
+Qed.
+
+Let catCIdentRight (x y : category) (f : @functor x y) :
+  compFunctor f idFunctor = f.
+Proof.
+  unfold compFunctor.
+  destruct f.
+  f_equal; apply proof_irrelevance.
+Qed.
+
+Definition catCategory : category := newCategory
+  category
+  (@functor)
+  (fun _ _ _ => compFunctor)
+  (fun _ => idFunctor)
+  catCAssoc
+  catCIdentLeft
+  catCIdentRight.

--- a/coq/CategoryTheory/Examples/Maybe.v
+++ b/coq/CategoryTheory/Examples/Maybe.v
@@ -7,6 +7,7 @@
 (*******************************************)
 
 Require Import FunctionalExtensionality.
+Require Import Main.CategoryTheory.Category.
 Require Import Main.CategoryTheory.Examples.Set.
 Require Import Main.CategoryTheory.Functor.
 Require Import Main.CategoryTheory.Monad.
@@ -21,73 +22,169 @@ Inductive maybe {x : Set} : Set :=
 
 (* Here is a proof that maybe is a functor. *)
 
-Definition maybeFunctor : @functor setCategory setCategory.
-Proof.
-  refine (
-    newFunctor setCategory setCategory
-    (@maybe)
-    (fun x y f e =>
+Let maybeFIdent (x : object setCategory) :
+  (
+    fun e : maybe =>
       match e with
       | nothing => nothing
-      | just e => just (f e)
+      | just e0 => just (@id setCategory x e0)
       end
+  ) = id setCategory.
+Proof.
+  clean.
+  apply functional_extensionality.
+  destruct x0; magic.
+Qed.
+
+Let maybeFComp
+  (x y z : object setCategory)
+  (f : arrow setCategory x y)
+  (g : arrow setCategory y z)
+: compose setCategory
+    (
+      fun e : maybe =>
+        match e with
+        | nothing => nothing
+        | just e0 => just (g e0)
+        end
     )
-    _ _
-  ); clean; apply functional_extensionality; intro; destruct x0; magic.
-Defined.
+    (
+      fun e : maybe =>
+        match e with
+        | nothing => nothing
+        | just e0 => just (f e0)
+        end
+    ) =
+  (
+    fun e : maybe =>
+      match e with
+      | nothing => nothing
+      | just e0 => just (compose setCategory g f e0)
+      end
+  ).
+Proof.
+  clean.
+  apply functional_extensionality.
+  destruct x0; magic.
+Qed.
+
+Definition maybeFunctor : @functor setCategory setCategory := newFunctor
+  setCategory
+  setCategory
+  (@maybe)
+  (fun _ _ f e =>
+    match e with
+    | nothing => nothing
+    | just e => just (f e)
+    end
+  )
+  maybeFIdent
+  maybeFComp.
 
 (* This is the "return" natural transformation for maybe. *)
 
-Definition maybeEta :
-  @naturalTransformation setCategory setCategory idFunctor maybeFunctor.
+Let maybeEtaNaturality (x y : object setCategory) (f : arrow setCategory x y) :
+  compose setCategory just (fMap idFunctor f) =
+  compose setCategory (fMap maybeFunctor f) just.
 Proof.
-  refine (
-    newNaturalTransformation setCategory setCategory idFunctor maybeFunctor
-    (@just)
-    _
-  ).
   magic.
-Defined.
+Qed.
+
+Definition maybeEta :
+  @naturalTransformation setCategory setCategory idFunctor maybeFunctor
+:= newNaturalTransformation
+  setCategory
+  setCategory
+  idFunctor
+  maybeFunctor
+  (@just)
+  maybeEtaNaturality.
 
 (* This is the "join" natural transformation for maybe. *)
 
-Definition maybeMu :
-  @naturalTransformation
+Let maybeMuNaturality (x y : object setCategory) (f : arrow setCategory x y) :
+  compose
     setCategory
+    (
+      fun e1 : oMap (compFunctor maybeFunctor maybeFunctor) y =>
+        match e1 with
+        | nothing => nothing
+        | just e2 => e2
+        end
+    )
+    (fMap (compFunctor maybeFunctor maybeFunctor) f) =
+  compose
     setCategory
-    (compFunctor maybeFunctor maybeFunctor)
-    maybeFunctor.
+    (fMap maybeFunctor f)
+    (
+      fun e1 : oMap (compFunctor maybeFunctor maybeFunctor) x =>
+        match e1 with
+        | nothing => nothing
+        | just e2 => e2
+        end
+    ).
 Proof.
-  refine (
-    newNaturalTransformation
-      setCategory
-      setCategory
-      (compFunctor maybeFunctor maybeFunctor)
-      maybeFunctor
-    (fun x e1 =>
+  clean.
+  apply functional_extensionality.
+  destruct x0; magic.
+Qed.
+
+Definition maybeMu : @naturalTransformation
+  setCategory
+  setCategory
+  (compFunctor maybeFunctor maybeFunctor)
+  maybeFunctor
+:= newNaturalTransformation
+  setCategory
+  setCategory
+  (compFunctor maybeFunctor maybeFunctor)
+  maybeFunctor
+  (
+    fun x e1 =>
       match e1 with
       | nothing => nothing
       | just e2 => e2
       end
-    )
-    _
-  ).
-  clean; apply functional_extensionality.
-  destruct x0; magic.
-Defined.
+  )
+  maybeMuNaturality.
 
 (* Now we can prove that maybe is a monad. *)
 
-Definition maybeMonad : monad maybeEta maybeMu.
+Let maybeMAssoc :
+  eta (compNaturalTransformation maybeMu (leftWhisker maybeMu maybeFunctor)) =
+  eta (compNaturalTransformation maybeMu (rightWhisker maybeFunctor maybeMu)).
 Proof.
-  refine (
-    newMonad setCategory maybeFunctor maybeEta maybeMu
-    _ _ _
-  );
-  magic;
-  apply functional_extensionality_dep;
-  clean;
-  apply functional_extensionality;
-  destruct x0;
+  clean.
+  apply functional_extensionality_dep.
+  clean.
+  apply functional_extensionality.
+  destruct x0; magic.
+Qed.
+
+Let maybeMIdent1 :
+  eta (compNaturalTransformation maybeMu (leftWhisker maybeEta maybeFunctor)) =
+  eta idNaturalTransformation.
+Proof.
   magic.
-Defined.
+Qed.
+
+Let maybeMIdent2 :
+  eta
+    (compNaturalTransformation maybeMu (rightWhisker maybeFunctor maybeEta)) =
+  eta idNaturalTransformation.
+Proof.
+  clean.
+  apply functional_extensionality_dep.
+  clean.
+  apply functional_extensionality.
+  destruct x0; magic.
+Qed.
+
+Definition maybeMonad : monad maybeEta maybeMu := newMonad
+  setCategory
+  maybeFunctor
+  maybeEta
+  maybeMu
+  maybeMAssoc
+  maybeMIdent1
+  maybeMIdent2.

--- a/coq/CategoryTheory/Examples/Set.v
+++ b/coq/CategoryTheory/Examples/Set.v
@@ -16,17 +16,23 @@ Open Scope type. (* Parse `*` as `prod` rather than `mul`. *)
 
 (* Sets and functions form a category. *)
 
-Definition setCategory : category.
+Let setCAssoc (w x y z : Set) (f : w -> x) (g : x -> y) (h : y -> z):
+  (fun e : w => h (g (f e))) = (fun e : w => h (g (f e))).
 Proof.
-  refine (
-    newCategory
-    Set
-    (fun x y => x -> y)
-    (fun x y z f g e => f (g e))
-    (fun x e => e)
-    _ _ _
-  ); magic.
-Defined.
+  magic.
+Qed.
+
+Let setCIdent (x y : Set) (f : x -> y) : (fun e : x => f e) = f.
+Proof.
+  magic.
+Qed.
+
+Definition setCategory : category := newCategory
+  Set
+  (fun x y => x -> y)
+  (fun x y z f g e => f (g e))
+  (fun x e => e)
+  setCAssoc setCIdent setCIdent.
 
 (* Cartesian products are categorical products in this category. *)
 

--- a/coq/CategoryTheory/Functor.v
+++ b/coq/CategoryTheory/Functor.v
@@ -15,11 +15,10 @@ Set Universe Polymorphism.
 
 Record functor {C D : category} := newFunctor {
   oMap : object C -> object D;
-  fMap : forall {x y}, arrow C x y -> arrow D (oMap x) (oMap y);
+  fMap {x y} : arrow C x y -> arrow D (oMap x) (oMap y);
 
-  fIdent : forall x, fMap (@id C x) = @id D (oMap x);
-  fComp :
-    forall x y z (f : arrow C x y) (g : arrow C y z),
+  fIdent x : fMap (@id C x) = @id D (oMap x);
+  fComp x y z (f : arrow C x y) (g : arrow C y z) :
     compose D (fMap g) (fMap f) = fMap (compose C g f);
 }.
 
@@ -28,24 +27,57 @@ Hint Rewrite @fIdent.
 Hint Resolve @fComp.
 Hint Rewrite @fComp.
 
-Definition idFunctor {C : category} : @functor C C.
+Let idFIdent {C : category} (x : object C) : @id C x = @id C x.
 Proof.
-  refine (newFunctor C C
-    (fun x => x)
-    (fun x y f => f)
-    _ _
-  ); magic.
-Defined.
+  magic.
+Qed.
+
+Let idFComp
+  {C : category}
+  (x y z : object C)
+  (f : arrow C x y)
+  (g : arrow C y z)
+: compose C g f = compose C g f.
+Proof.
+  magic.
+Qed.
+
+Definition idFunctor {C : category} : @functor C C := newFunctor C C
+  (fun x => x)
+  (fun x y f => f)
+  idFIdent
+  idFComp.
+
+Let compFIdent
+  {C D E : category}
+  {G : @functor D E}
+  {F : @functor C D}
+  (x : object C)
+: fMap G (fMap F (@id C x)) = id E.
+Proof.
+  magic.
+Qed.
+
+Let compFComp
+  {C D E : category}
+  {G : @functor D E}
+  {F : @functor C D}
+  (x y z : object C)
+  (f : arrow C x y)
+  (g : arrow C y z)
+: compose E (fMap G (fMap F g)) (fMap G (fMap F f)) =
+  fMap G (fMap F (compose C g f)).
+Proof.
+  magic.
+Qed.
 
 Definition compFunctor
   {C D E : category}
   (G : @functor D E)
   (F : @functor C D) :
-  @functor C E.
-Proof.
-  refine (newFunctor C E
-    (fun (x : object C) => oMap G (oMap F x))
-    (fun {x y : object C} (f : arrow C x y) => fMap G (fMap F f))
-    _ _
-  ); magic.
-Defined.
+  @functor C E
+:= newFunctor C E
+  (fun (x : object C) => oMap G (oMap F x))
+  (fun {x y : object C} (f : arrow C x y) => fMap G (fMap F f))
+  compFIdent
+  compFComp.

--- a/coq/CategoryTheory/NaturalTransformation.v
+++ b/coq/CategoryTheory/NaturalTransformation.v
@@ -19,77 +19,106 @@ Record naturalTransformation
   {C D : category}
   {F G : @functor C D} :=
 newNaturalTransformation {
-  eta : forall x, arrow D (oMap F x) (oMap G x);
+  eta x : arrow D (oMap F x) (oMap G x);
 
-  naturality :
-    forall x y (f : arrow C x y),
+  naturality x y (f : arrow C x y) :
     compose D (eta y) (fMap F f) = compose D (fMap G f) (eta x);
 }.
 
 Hint Resolve @naturality.
+Hint Rewrite @naturality.
+
+Let idNaturality
+  {C D : category}
+  {F : @functor C D}
+  (x y : object C)
+  (f : arrow C x y)
+: compose D (id D) (fMap F f) = compose D (fMap F f) (id D).
+Proof.
+  magic.
+Qed.
 
 Definition idNaturalTransformation
   {C D : category}
   {F : @functor C D} :
-  @naturalTransformation C D F F.
-Proof.
-  refine (
-    newNaturalTransformation C D F F
-    (fun x => id D)
-    _
-  ).
-  magic.
-Defined.
+  @naturalTransformation C D F F
+:= newNaturalTransformation C D F F
+  (fun x => id D)
+  idNaturality.
 
-Definition compNaturalTransformation
+Let compNaturality
   {C D : category}
   {F G H : @functor C D}
-  (Eta : @naturalTransformation C D G H)
-  (Mu : @naturalTransformation C D F G) :
-  @naturalTransformation C D F H.
+  {Eta : @naturalTransformation C D G H}
+  {Mu : @naturalTransformation C D F G}
+  (x y : object C) (f : arrow C x y)
+: compose D (compose D (eta Eta y) (eta Mu y)) (fMap F f) =
+  compose D (fMap H f) (compose D (eta Eta x) (eta Mu x)).
 Proof.
-  refine (
-    newNaturalTransformation C D F H
-    (fun x => compose D (eta Eta x) (eta Mu x))
-    _
-  ).
-  clean.
   rewrite cAssoc.
   rewrite <- cAssoc.
   replace (compose D (eta Mu y) (fMap F f)) with
     (compose D (fMap G f) (eta Mu x)); magic.
   replace (compose D (fMap H f) (eta Eta x)) with
     (compose D (eta Eta y) (fMap G f)); magic.
-Defined.
+Qed.
+
+Definition compNaturalTransformation
+  {C D : category}
+  {F G H : @functor C D}
+  (Eta : @naturalTransformation C D G H)
+  (Mu : @naturalTransformation C D F G) :
+  @naturalTransformation C D F H
+:= newNaturalTransformation C D F H
+    (fun x => compose D (eta Eta x) (eta Mu x))
+    compNaturality.
+
+Let rightWhiskerNaturality
+  {C D E : category}
+  {F G : @functor C D}
+  {H : @functor D E}
+  {Eta : @naturalTransformation C D F G}
+  (x y : object C) (f : arrow C x y)
+: compose E (fMap H (eta Eta y)) (fMap (compFunctor H F) f) =
+  compose E (fMap (compFunctor H G) f)  (fMap H (eta Eta x)).
+Proof.
+  magic.
+Qed.
 
 Definition rightWhisker
   {C D E : category}
   {F G : @functor C D}
   (H : @functor D E)
   (Eta : @naturalTransformation C D F G) :
-  @naturalTransformation C E (compFunctor H F) (compFunctor H G).
+  @naturalTransformation C E (compFunctor H F) (compFunctor H G)
+:= newNaturalTransformation C E (compFunctor H F) (compFunctor H G)
+  (fun x => fMap H (eta Eta x))
+  rightWhiskerNaturality.
+
+Let leftWhiskerNaturality
+  {C D E : category}
+  {F G : @functor D E}
+  {Eta : @naturalTransformation D E F G}
+  {H : @functor C D}
+  (x y : object C)
+  (f : arrow C x y)
+: compose E (eta Eta (oMap H y))
+    (fMap (compFunctor F H) f) =
+  compose E (fMap (compFunctor G H) f)
+    (eta Eta (oMap H x)).
 Proof.
-  refine (
-    newNaturalTransformation C E (compFunctor H F) (compFunctor H G)
-    (fun x => fMap H (eta Eta x))
-    _
-  ). magic.
-Defined.
+  magic.
+Qed.
 
 Definition leftWhisker
   {C D E : category}
   {F G : @functor D E}
   (Eta : @naturalTransformation D E F G)
   (H : @functor C D) :
-  @naturalTransformation C E (compFunctor F H) (compFunctor G H).
-Proof.
-  refine (
-    newNaturalTransformation C E (compFunctor F H) (compFunctor G H)
+  @naturalTransformation C E (compFunctor F H) (compFunctor G H)
+:= newNaturalTransformation C E (compFunctor F H) (compFunctor G H)
     (fun x => eta Eta (oMap H x))
-    _
-  ).
-  magic.
-Defined.
+    leftWhiskerNaturality.
 
 Definition naturalIsomorphism
   {C D F G}

--- a/coq/CategoryTheory/Object.v
+++ b/coq/CategoryTheory/Object.v
@@ -30,8 +30,7 @@ Definition terminal {C} x :=
   exists f,
   forall (g : arrow C y x), f = g.
 
-Theorem isomorphicRefl :
-  forall C x, @isomorphic C x x.
+Theorem isomorphicRefl C x : @isomorphic C x x.
 Proof.
   unfold isomorphic.
   unfold isomorphism.
@@ -41,11 +40,8 @@ Qed.
 
 Hint Resolve isomorphicRefl.
 
-Theorem isomorphicTrans :
-  forall C x y z,
-  @isomorphic C x y ->
-  @isomorphic C y z ->
-  @isomorphic C x z.
+Theorem isomorphicTrans C x y z :
+  @isomorphic C x y -> @isomorphic C y z -> @isomorphic C x z.
 Proof.
   unfold isomorphic.
   unfold isomorphism.
@@ -69,8 +65,7 @@ Qed.
   so could lead to nonterminating searches.
 *)
 
-Theorem isomorphicSymm :
-  forall C x y, @isomorphic C x y <-> @isomorphic C y x.
+Theorem isomorphicSymm C x y : @isomorphic C x y <-> @isomorphic C y x.
 Proof.
   unfold isomorphic.
   unfold isomorphism.
@@ -83,8 +78,8 @@ Qed.
   so could lead to nonterminating searches.
 *)
 
-Theorem opIsomorphic :
-  forall C x y, @isomorphic C x y <-> @isomorphic (oppositeCategory C) y x.
+Theorem opIsomorphic C x y :
+  @isomorphic C x y <-> @isomorphic (oppositeCategory C) y x.
 Proof.
   unfold isomorphic.
   split; clean; exists x0; [
@@ -94,18 +89,15 @@ Qed.
 
 Hint Resolve opIsomorphic.
 
-Theorem opInitialTerminal :
-  forall C x,
-  @initial C x <->
-  @terminal (oppositeCategory C) x.
+Theorem opInitialTerminal C x :
+  @initial C x <-> @terminal (oppositeCategory C) x.
 Proof.
   magic.
 Qed.
 
 Hint Resolve opInitialTerminal.
 
-Theorem opTerminalInitial :
-  forall C x,
+Theorem opTerminalInitial C x :
   @terminal C x <->
   @initial (oppositeCategory C) x.
 Proof.
@@ -114,7 +106,7 @@ Qed.
 
 Hint Resolve opTerminalInitial.
 
-Theorem initialUnique : forall C, uniqueUpToIsomorphism (@initial C).
+Theorem initialUnique C : uniqueUpToIsomorphism (@initial C).
 Proof.
   unfold uniqueUpToIsomorphism.
   unfold initial.
@@ -131,7 +123,7 @@ Qed.
 
 Hint Resolve initialUnique.
 
-Theorem terminalUnique : forall C, uniqueUpToIsomorphism (@terminal C).
+Theorem terminalUnique C : uniqueUpToIsomorphism (@terminal C).
 Proof.
   unfold uniqueUpToIsomorphism.
   clean.

--- a/coq/CategoryTheory/Product.v
+++ b/coq/CategoryTheory/Product.v
@@ -28,8 +28,7 @@ Definition product
     (qy : arrow C z y),
   universal (fun f => qx = compose C px f /\ qy = compose C py f).
 
-Theorem productUnique :
-  forall C (x y : object C),
+Theorem productUnique C (x y : object C) :
   uniqueUpToIsomorphism (fun xy => exists px py, product x y xy px py).
 Proof.
   clean.

--- a/coq/CategoryTheory/ProductCategory.v
+++ b/coq/CategoryTheory/ProductCategory.v
@@ -14,25 +14,110 @@ Set Universe Polymorphism.
 
 Open Scope type. (* Parse `*` as `prod` rather than `mul`. *)
 
-Definition productCategory (C D : category) : category.
+Let productCategoryCAssoc
+  {C D : category}
+  (w x y z : object C * object D)
+  (f : arrow C (fst w) (fst x) * arrow D (snd w) (snd x))
+  (g : arrow C (fst x) (fst y) * arrow D (snd x) (snd y))
+  (h : arrow C (fst y) (fst z) * arrow D (snd y) (snd z))
+: (
+    compose C
+      (fst h)
+      (fst (compose C (fst g) (fst f), compose D (snd g) (snd f))),
+    compose D
+      (snd h)
+      (snd (compose C (fst g) (fst f), compose D (snd g) (snd f)))
+  ) = (
+    compose C
+      (fst (compose C (fst h) (fst g), compose D (snd h) (snd g)))
+      (fst f),
+    compose D
+      (snd (compose C (fst h) (fst g), compose D (snd h) (snd g)))
+      (snd f)
+  ).
 Proof.
-  refine (newCategory
-    (object C * object D)
-    (fun x y => arrow C (fst x) (fst y) * arrow D (snd x) (snd y))
-    (fun {x y z} f g => (compose C (fst f) (fst g), compose D (snd f) (snd g)))
-    (fun {x} => (id C, id D))
-    _ _ _
-  ); magic.
-Defined.
+  magic.
+Qed.
+
+Let productCategoryCIdentLeft
+  {C D : category}
+  (x y : object C * object D)
+  (f : arrow C (fst x) (fst y) * arrow D (snd x) (snd y))
+: (
+    compose C (fst (@id C (fst y), @id D (snd y))) (fst f),
+    compose D (snd (@id C (fst y), @id D (snd y))) (snd f)
+  ) = f.
+Proof.
+  magic.
+Qed.
+
+Let productCategoryCIdentRight
+  {C D : category}
+  (x y : object C * object D)
+  (f : arrow C (fst x) (fst y) * arrow D (snd x) (snd y))
+: (
+    compose C (fst f) (fst (@id C (fst x), @id D (snd x))),
+    compose D (snd f) (snd (@id C (fst x), @id D (snd x)))
+  ) = f.
+Proof.
+  magic.
+Qed.
+
+Definition productCategory (C D : category) : category := newCategory
+  (object C * object D)
+  (fun x y => arrow C (fst x) (fst y) * arrow D (snd x) (snd y))
+  (fun {x y z} f g => (compose C (fst f) (fst g), compose D (snd f) (snd g)))
+  (fun {x} => (id C, id D))
+  productCategoryCAssoc
+  productCategoryCIdentLeft
+  productCategoryCIdentRight.
+
+Let productCategoryProj1FIdent
+  {C D : category}
+  (x : object (productCategory C D))
+: fst (@id (productCategory C D) x) = id C.
+Proof.
+  magic.
+Qed.
+
+Let productCategoryProj1FComp
+  {C D : category}
+  (x y z : object (productCategory C D))
+  (f : arrow (productCategory C D) x y)
+  (g : arrow (productCategory C D) y z)
+: compose C (fst g) (fst f) = fst (compose (productCategory C D) g f).
+Proof.
+  magic.
+Qed.
 
 Definition productCategoryProj1 (C D : category) :
-  @functor (productCategory C D) C.
+  @functor (productCategory C D) C := newFunctor
+    (productCategory C D)
+    C
+    fst
+    (fun _ _ => fst) productCategoryProj1FIdent productCategoryProj1FComp.
+
+Let productCategoryProj2FIdent
+  {C D : category}
+  (x : object (productCategory C D))
+: snd (@id (productCategory C D) x) = id D.
 Proof.
-  refine (newFunctor (productCategory C D) C fst (fun _ _ => fst) _ _); magic.
-Defined.
+  magic.
+Qed.
+
+Let productCategoryProj2FComp
+  {C D : category}
+  (x y z : object (productCategory C D))
+  (f : arrow (productCategory C D) x y)
+  (g : arrow (productCategory C D) y z)
+: compose D (snd g) (snd f) = snd (compose (productCategory C D) g f).
+Proof.
+  magic.
+Qed.
 
 Definition productCategoryProj2 (C D : category) :
-  @functor (productCategory C D) D.
-Proof.
-  refine (newFunctor (productCategory C D) D snd (fun _ _ => snd) _ _); magic.
-Defined.
+  @functor (productCategory C D) D := newFunctor
+    (productCategory C D)
+    D
+    snd
+    (fun _ _ => snd) productCategoryProj2FIdent productCategoryProj2FComp.


### PR DESCRIPTION
Refactor some of the category theory development. In particular:

- For theorems whose type begin with `forall`, I just made the quantified variables parameters of the theorem. This is equivalent and shorter.
- I made invocations of `proof_irrelevance`, `functional_extensionality`, `functional_extensionality_dep` always explicit. Previously they were sometimes added as hints (within a section).
- I made all theorems opaque, such that only the computational contents of categories, functors, etc. are transparent. This makes proof terms smaller and easier to work with.