### PR TITLE
Use `Type` instead of `Set`

### DIFF
--- a/coq/CategoryTheory/Examples/Maybe.v
+++ b/coq/CategoryTheory/Examples/Maybe.v
@@ -16,11 +16,11 @@ Require Import Main.Tactics.
 
 (* A maybe is a wrapper for value that might be missing. *)
 
-Inductive maybe {x : Set} : Set :=
+Inductive maybe {x} : Type :=
 | nothing : @maybe x
 | just : x -> @maybe x.
 
-(* Here is a proof that maybe is a functor. *)
+(* Here's a proof that maybe is a functor. *)
 
 Let maybeFIdent (x : object setCategory) :
   (

--- a/coq/CategoryTheory/Examples/Set.v
+++ b/coq/CategoryTheory/Examples/Set.v
@@ -16,19 +16,19 @@ Open Scope type. (* Parse `*` as `prod` rather than `mul`. *)
 
 (* Sets and functions form a category. *)
 
-Let setCAssoc (w x y z : Set) (f : w -> x) (g : x -> y) (h : y -> z):
+Let setCAssoc w x y z (f : w -> x) (g : x -> y) (h : y -> z):
   (fun e : w => h (g (f e))) = (fun e : w => h (g (f e))).
 Proof.
   magic.
 Qed.
 
-Let setCIdent (x y : Set) (f : x -> y) : (fun e : x => f e) = f.
+Let setCIdent x y (f : x -> y) : (fun e : x => f e) = f.
 Proof.
   magic.
 Qed.
 
 Definition setCategory : category := newCategory
-  Set
+  Type
   (fun x y => x -> y)
   (fun x y z f g e => f (g e))
   (fun x e => e)
@@ -36,7 +36,7 @@ Definition setCategory : category := newCategory
 
 (* Cartesian products are categorical products in this category. *)
 
-Theorem cartesianProduct (x y : Set) :
+Theorem cartesianProduct x y :
   @product setCategory x y (x * y) fst snd.
 Proof.
   unfold product.

--- a/coq/Intro/Lesson0_Intro.v
+++ b/coq/Intro/Lesson0_Intro.v
@@ -8,7 +8,7 @@
 
 (* Let's define a data type for Booleans. *)
 
-Inductive bool : Set :=
+Inductive bool :=
 | true : bool
 | false : bool.
 
@@ -35,7 +35,7 @@ Compute negb false. (* true *)
   zero or the successor of another natural number.
 *)
 
-Inductive nat : Set :=
+Inductive nat :=
 | O : nat
 | S : nat -> nat.
 

--- a/coq/Intro/Lesson1_DependentTypes.v
+++ b/coq/Intro/Lesson1_DependentTypes.v
@@ -10,7 +10,7 @@ Require Import String.
 
 (* A length-indexed list of strings *)
 
-Inductive slist : nat -> Set :=
+Inductive slist : nat -> Type :=
 | snil : slist O
 | scons :
     forall {n}, (* Length of the tail, implicit due to the curly braces *)

--- a/coq/Intro/Lesson2_Logic.v
+++ b/coq/Intro/Lesson2_Logic.v
@@ -96,7 +96,7 @@ Print not_false. (* fun H : False => H *)
 
 (* Propositional equality *)
 
-Inductive eq (A : Type) (x : A) : A -> Prop := (* Notation: x = x *)
+Inductive eq A (x : A) : A -> Prop := (* Notation: x = x *)
 | eq_refl : eq A x x. (* A dependent type! *)
 
 (* A simple proof that 0 = 0. *)
@@ -110,7 +110,7 @@ Qed.
   equaltiy".
 *)
 
-Definition leibniz (A : Type)
+Definition leibniz A
                    (x : A)
                    (P : A -> Prop)
                    (f : P x)
@@ -145,7 +145,7 @@ Check eq_ind.
   quantification, however, is definable as follows:
 *)
 
-Inductive ex (A : Type)
+Inductive ex A
              (P : A -> Prop) :
              Prop := (* Notation: exists x, P x *)
   ex_intro : forall x : A, P x -> ex A P.

--- a/coq/Kleene.v
+++ b/coq/Kleene.v
@@ -20,7 +20,7 @@ Section Kleene.
     antisymmetric.
   *)
 
-  Variable T : Set.
+  Variable T : Type.
   Variable leq : T -> T -> Prop.
 
   Hypothesis refl : forall x, leq x x.

--- a/coq/Metatheory.v
+++ b/coq/Metatheory.v
@@ -63,7 +63,7 @@ Definition idUniverse (t : universe) (x : t) := x.
 (*
   The following is not allowed:
 
-  Inductive bad : Set :=
+  Inductive bad :=
   | makeBad : (bad -> bool) -> bad.
 
   Suppose bad were allowed. Consider the following function:

--- a/coq/STLC/Name.v
+++ b/coq/STLC/Name.v
@@ -10,7 +10,7 @@ Require Import Main.Tactics.
 
 Module Type NameSig.
 
-  Parameter name : Set.
+  Parameter name : Type.
 
   Axiom nameEq : forall x1 x2 : name, { x1 = x2 } + { x1 <> x2 }.
 

--- a/coq/STLC/Syntax.v
+++ b/coq/STLC/Syntax.v
@@ -8,7 +8,7 @@
 
 Require Import Main.STLC.Name.
 
-Inductive term : Set :=
+Inductive term :=
 | eTrue : term
 | eFalse : term
 | eIf : term -> term -> term -> term
@@ -16,6 +16,6 @@ Inductive term : Set :=
 | eAbs : name -> type -> term -> term
 | eApp : term -> term -> term
 
-with type : Set :=
+with type :=
 | tBool : type
 | tArrow : type -> type -> type.

--- a/coq/SystemF/Name.v
+++ b/coq/SystemF/Name.v
@@ -11,7 +11,7 @@ Require Import Main.Tactics.
 
 Module Type NameSig.
 
-  Parameter name : Set.
+  Parameter name : Type.
 
   Axiom nameEq : forall x1 x2 : name, { x1 = x2 } + { x1 <> x2 }.
 

--- a/coq/SystemF/Syntax.v
+++ b/coq/SystemF/Syntax.v
@@ -8,7 +8,7 @@
 
 Require Import Main.SystemF.Name.
 
-Inductive term : Set :=
+Inductive term :=
 | eFreeVar : name -> term
 | eBoundVar : nat -> term
 | eAbs : type -> term -> term
@@ -16,7 +16,7 @@ Inductive term : Set :=
 | eTAbs : term -> term
 | eTApp : term -> type -> term
 
-with type : Set :=
+with type :=
 | tFreeVar : name -> type
 | tBoundVar : nat -> type
 | tArrow : type -> type -> type


### PR DESCRIPTION
Use `Type` instead of `Set` where a universe is required, otherwise just leave it out (Coq seems to default to `Type` already).