### PR TITLE
Prove categorically that 1 * X = X and X = 0 + X

### DIFF
--- a/coq/CategoryTheory/Coproduct.v
+++ b/coq/CategoryTheory/Coproduct.v
@@ -55,6 +55,22 @@ Qed.
 
 Hint Resolve coproductUnique.
 
+Theorem coproductCommutator
+  {C}
+  (x y xy : object C)
+  (ix : arrow x xy)
+  (iy : arrow y xy)
+: coproduct x y xy ix iy -> coproduct y x xy iy ix.
+Proof.
+  repeat rewrite opCoproductProduct.
+  apply productCommutator.
+Qed.
+
+(*
+  We deliberately avoid adding a resolve hint for coproductCommutator because
+  doing so could lead to nonterminating searches.
+*)
+
 Theorem coproductCommutative
   {C}
   (x y xy yx : object C)

--- a/coq/CategoryTheory/Coproduct.v
+++ b/coq/CategoryTheory/Coproduct.v
@@ -8,8 +8,10 @@
 
 Require Import Main.CategoryTheory.Arrow.
 Require Import Main.CategoryTheory.Category.
+Require Import Main.CategoryTheory.Initial.
 Require Import Main.CategoryTheory.Object.
 Require Import Main.CategoryTheory.Product.
+Require Import Main.CategoryTheory.Terminal.
 Require Import Main.Tactics.
 
 Set Universe Polymorphism.
@@ -110,3 +112,18 @@ Proof.
 Qed.
 
 Hint Resolve coproductAssociative.
+
+Theorem coproductInitial
+  {C}
+  (x y xy : object C)
+  (x_to_xy : arrow x xy)
+  (y_to_xy : arrow y xy)
+: coproduct x y xy x_to_xy y_to_xy -> initial x -> isomorphic y xy.
+Proof.
+  rewrite opCoproductProduct.
+  rewrite opInitialTerminal.
+  rewrite opIsomorphic.
+  apply productTerminal.
+Qed.
+
+Hint Resolve coproductInitial.

--- a/coq/CategoryTheory/Product.v
+++ b/coq/CategoryTheory/Product.v
@@ -9,6 +9,7 @@
 Require Import Main.CategoryTheory.Arrow.
 Require Import Main.CategoryTheory.Category.
 Require Import Main.CategoryTheory.Object.
+Require Import Main.CategoryTheory.Terminal.
 Require Import Main.Tactics.
 
 Set Universe Polymorphism.
@@ -250,3 +251,35 @@ Proof.
 Qed.
 
 Hint Resolve productAssociative.
+
+Theorem productTerminal
+  {C}
+  (x y xy : object C)
+  (xy_to_x : arrow xy x)
+  (xy_to_y : arrow xy y)
+: product x y xy xy_to_x xy_to_y -> terminal x -> isomorphic xy y.
+Proof.
+  unfold terminal.
+  clean.
+  fact (H0 y).
+  clean.
+  assert (product x y y x0 id).
+  - clear H1.
+    unfold product.
+    clean.
+    unfold universal.
+    split.
+    + unfold arrowExists.
+      exists qy.
+      split; magic.
+      specialize (H0 z).
+      magic.
+    + unfold arrowUnique.
+      magic.
+  - fact (productUnique C x y).
+    unfold uniqueUpToIsomorphism in H3.
+    specialize (H3 xy y).
+    eMagic.
+Qed.
+
+Hint Resolve productTerminal.


### PR DESCRIPTION
Prove categorically that `1 * X = X` and `X = 0 + X` (up to isomorphism), where `1` is a terminal object and `0` is an initial object.