### PR TITLE
Bring back the Makefile for working with CoqIDE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: verify clean
+
+verify:
+	rm -f .coqdeps.d Makefile.coq Makefile.coq.conf _CoqProjectFull
+	echo '-R coq Main' > _CoqProjectFull
+	find coq -type f -name '*.v' >> _CoqProjectFull
+	coq_makefile -f _CoqProjectFull -o Makefile.coq || \
+	  (rm -f .coqdeps.d Makefile.coq Makefile.coq.conf _CoqProjectFull; exit 1)
+	make -f Makefile.coq || \
+	  (rm -f .coqdeps.d Makefile.coq Makefile.coq.conf _CoqProjectFull; exit 1)
+	rm -f .coqdeps.d Makefile.coq Makefile.coq.conf _CoqProjectFull
+
+clean:
+	rm -f _CoqProjectFull Makefile.coq \
+	  $(shell \
+	    find . -type d \( \
+	      -path ./.git \
+	    \) -prune -o \( \
+	      -name '*.aux' -o \
+	      -name '*.glob' -o \
+	      -name '*.vo' -o \
+	      -name '.coqdeps.d' -o \
+	      -name 'Makefile.coq' -o \
+	      -name 'Makefile.coq.conf' -o \
+	      -name '_CoqProjectFull' \
+	    \) -print \
+	  )

--- a/README.md
+++ b/README.md
@@ -6,4 +6,13 @@ A selection of formal developments in [Coq](https://coq.inria.fr/).
 
 ## Instructions
 
-Make sure you have [Toast](https://github.com/stepchowfun/toast) installed. Then you can run `toast verify` to verify the proofs.
+Make sure you have the dependencies listed below. Then you can run `make` to verify the proofs. You can also use `make lint` to invoke the linters. The build artifacts can be removed with `make clean`.
+
+## Dependencies
+
+The build system depends on the following:
+
+- [GNU Make](https://www.gnu.org/software/make/) >= 3.79.1
+- [Coq](https://coq.inria.fr/) >= 8.7.2
+
+You also need the usual set of Unix tools, such as `echo`, `find`, etc.

--- a/scripts/lint-general.rb
+++ b/scripts/lint-general.rb
@@ -18,12 +18,24 @@ ARGV.each do |path|
 
   # Iterate over the lines of the file.
   lines.each_with_index do |line, index|
-    # Check for any tabs.
-    if line =~ /\t/
-      STDERR.puts(
-        "Error: Line #{index + 1} of #{path} has a tab."
-      )
-      failed = true
+    # Check for tabs, with special behavior for files called `Makefile`.
+    if File.basename(path) == 'Makefile'
+      # Check for tabs which are not the first character of the line.
+      if line =~ /.\t/
+        STDERR.puts(
+          "Error: Line #{index + 1} of #{path} has a tab in a non-required " \
+            "position."
+        )
+        failed = true
+      end
+    else
+      # Check for any tabs.
+      if line =~ /\t/
+        STDERR.puts(
+          "Error: Line #{index + 1} of #{path} has a tab."
+        )
+        failed = true
+      end
     end
 
     # Check the line length.

--- a/toast.yml
+++ b/toast.yml
@@ -32,19 +32,16 @@ tasks:
     dependencies:
       - prepare_system
     input_paths:
+      - Makefile
       - _CoqProject
-      - coq
-    output_paths:
       - coq
     user: user
     command: |
       set -euo pipefail
 
       # Run Coq on the proof scripts.
-      echo '-R coq Main' > _CoqProjectFull
-      find coq -type f -name '*.v' >> _CoqProjectFull
-      coq_makefile -f _CoqProjectFull -o Makefile.coq
-      make -f Makefile.coq
+      make clean
+      make
 
   lint:
     description: Run the linters.


### PR DESCRIPTION
Bring back the Makefile (removed in https://github.com/stepchowfun/proofs/pull/182) for working with CoqIDE. After this change, [Toast](https://github.com/stepchowfun/toast) is only used for CI but not for local development. It would be nice to use Toast for local development as well, but apparently Coq modules that are compiled in Linux (via Docker) can't be used on macOS by CoqIDE. So we need a way to compile Coq code on the host.