### PR TITLE
Switch from Travis to GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: Continuous integration
+on: [push, pull_request]
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: azure/docker-login@v1
+      with:
+        username: stephanmisc
+        password: ${{ secrets.DOCKER_PASSWORD }}
+      if: github.event_name == 'push'
+    - uses: stepchowfun/toast/.github/actions/toast@master
+      with:
+        tasks: verify lint
+        repo: stephanmisc/toast
+        write_remote_cache: ${{ github.event_name == 'push' }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A selection of formal proofs in [Coq](https://coq.inria.fr/).
 
-[![Build Status](https://travis-ci.org/stepchowfun/proofs.svg?branch=master)](https://travis-ci.org/stepchowfun/proofs)
+[![Build status](https://github.com/stepchowfun/proofs/workflows/Continuous%20integration/badge.svg?branch=master)](https://github.com/stepchowfun/proofs/actions?query=branch%3Amaster)
 
 ## Instructions
 


### PR DESCRIPTION
Switch from Travis to GitHub Actions for CI.