### PR TITLE
Use `docker_repo` instead of `docker` in the Toast action in the GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,5 @@ jobs:
     - uses: stepchowfun/toast/.github/actions/toast@main
       with:
         tasks: verify lint
-        repo: stephanmisc/toast
+        docker_repo: stephanmisc/toast
         write_remote_cache: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
Use `docker_repo` instead of `docker` in the Toast action in the GitHub workflow.

**Status:** Ready

**Fixes:** N/A