### PR TITLE
Require imports to have absolute names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,40 +2,40 @@
 
 verify:
 	rm -f \
-          .Makefile.coq.d \
+          .CoqMakefile.d \
           .lia.cache \
-          Makefile.coq \
-          Makefile.coq.conf \
+          CoqMakefile \
+          CoqMakefile.conf \
           _CoqProjectFull
-	echo '-R proofs Main' > _CoqProjectFull
+	echo '-Q proofs Main' > _CoqProjectFull
 	find proofs -type f -name '*.v' >> _CoqProjectFull
-	coq_makefile -f _CoqProjectFull -o Makefile.coq || (rm -f \
-            .Makefile.coq.d \
+	coq_makefile -f _CoqProjectFull -o CoqMakefile || (rm -f \
+            .CoqMakefile.d \
             .lia.cache \
-            Makefile.coq \
-            Makefile.coq.conf \
+            CoqMakefile \
+            CoqMakefile.conf \
             _CoqProjectFull; \
           exit 1)
-	make -f Makefile.coq || (rm -f \
-            .Makefile.coq.d \
+	make -f CoqMakefile || (rm -f \
+            .CoqMakefile.d \
             .lia.cache \
-            Makefile.coq \
-            Makefile.coq.conf \
+            CoqMakefile \
+            CoqMakefile.conf \
             _CoqProjectFull; \
           exit 1)
 	rm -f \
-          .Makefile.coq.d \
+          .CoqMakefile.d \
           .lia.cache \
-          Makefile.coq \
-          Makefile.coq.conf \
+          CoqMakefile \
+          CoqMakefile.conf \
           _CoqProjectFull
 
 clean:
 	rm -f \
-          .Makefile.coq.d \
+          .CoqMakefile.d \
           .lia.cache \
-          Makefile.coq \
-          Makefile.coq.conf \
+          CoqMakefile \
+          CoqMakefile.conf \
           _CoqProjectFull \
 	  $(shell \
 	    find . -type d \( \

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,2 +1,2 @@
 # This file is used by CoqIDE.
--R proofs Main
+-Q proofs Main


### PR DESCRIPTION
Require imports to have absolute names.