### PR TITLE
Show that recursive occurrences of inductive types must be strictly positive, not just positive

### DIFF
--- a/proofs/Tutorial/Lesson5_Totality.v
+++ b/proofs/Tutorial/Lesson5_Totality.v
@@ -6,6 +6,14 @@
 (***************************************************************************)
 (***************************************************************************)
 
+(********************************************************)
+(* All functions must be statically known to terminate. *)
+(********************************************************)
+
+(*
+  Fixpoint f (n : nat) : nat := f n.
+*)
+
 (***************************************************)
 (* A brief summary of the universe behavior in Coq *)
 (***************************************************)
@@ -56,17 +64,10 @@ Definition idUniverse (t : universe) (x : t) := x.
   Check idUniverse (forall t : universe, t -> t) idUniverse.
 *)
 
-(********************************************************)
-(* All functions must be statically known to terminate. *)
-(********************************************************)
-
-(*
-  Fixpoint f (n : nat) : nat := f n.
-*)
-
-(***********************************************************)
-(* Inductive types have a "strict positivity requirement". *)
-(***********************************************************)
+(*****************************************************************************)
+(* Inductive types have a "strict positivity requirement" to prevent Curry's *)
+(* paradox.                                                                  *)
+(*****************************************************************************)
 
 (*
   The following is not allowed:
@@ -84,4 +85,17 @@ Definition idUniverse (t : universe) (x : t) := x.
   We could use evil to construct the following diverging term:
 
   Definition catastrophe : bool := evil (makeBad evil).
+
+  Note that this is also rejected:
+
+  Inductive alsoBad :=
+  | makeAlsoBad : ((alsoBad -> bool) -> bool) -> alsoBad.
+
+  alsoBad can be used to construct a diverging function in an impredicative
+  universe, as demonstrated in this paper:
+
+  Coquand, T., Paulin, C. (1990). Inductively defined types. In: Martin-Löf,
+  P., Mints, G. (eds) COLOG-88. COLOG 1988. Lecture Notes in Computer Science,
+  vol 417. Springer, Berlin, Heidelberg.
+  https://doi.org/10.1007/3-540-52335-9_47
 *)


### PR DESCRIPTION
Show that recursive occurrences of inductive types must be strictly positive, not just positive.

**Status:** Ready

**Fixes:** N/A