### PR TITLE
Use backticks to delimit code-like text

### DIFF
--- a/proofs/CategoryTheory/Category.v
+++ b/proofs/CategoryTheory/Category.v
@@ -11,11 +11,11 @@ Require Import Main.Tactics.
 
 #[local] Set Universe Polymorphism.
 
-(* Metavariables for categories: C, D, E *)
+(* Metavariables for categories: `C`, `D`, `E` *)
 
 Record category := newCategory {
-  object : Type; (* Metavariables for objects: w, x, y, z *)
-  arrow : object -> object -> Type; (* Metavariables for arrows: f, g, h *)
+  object : Type; (* Objects: `w`, `x`, `y`, `z` *)
+  arrow : object -> object -> Type; (* Arrows: `f`, `g`, `h` *)
   compose {x y z} : arrow y z -> arrow x y -> arrow x z;
   id {x}: arrow x x;
 

--- a/proofs/CategoryTheory/Coproduct.v
+++ b/proofs/CategoryTheory/Coproduct.v
@@ -17,8 +17,8 @@ Require Import Main.Tactics.
 
 #[local] Set Universe Polymorphism.
 
-(* Metavariable for coproducts: xy (same as products) *)
-(* Metavariables for injections: ix, iy *)
+(* Metavariable for coproducts: `xy` (same as products) *)
+(* Metavariables for injections: `ix`, `iy` *)
 
 Definition coproduct
   {C}
@@ -70,7 +70,7 @@ Proof.
 Qed.
 
 (*
-  We deliberately avoid adding a resolve hint for coproductCommutator because
+  We deliberately avoid adding a resolve hint for `coproductCommutator` because
   doing so could lead to nonterminating searches.
 *)
 

--- a/proofs/CategoryTheory/Examples/Maybe.v
+++ b/proofs/CategoryTheory/Examples/Maybe.v
@@ -14,7 +14,7 @@ Require Import Main.CategoryTheory.Monad.
 Require Import Main.CategoryTheory.NaturalTransformation.
 Require Import Main.Tactics.
 
-(* A maybe is a wrapper for value that might be missing. *)
+(* A `maybe` is a wrapper for value that might be missing. *)
 
 Inductive maybe x : Type :=
 | nothing : maybe x
@@ -23,7 +23,7 @@ Inductive maybe x : Type :=
 Arguments nothing {_}.
 Arguments just {_}.
 
-(* Here's a proof that maybe is a functor. *)
+(* Here's a proof that `maybe` is a functor. *)
 
 #[local] Theorem maybeFIdent (x : object setCategory) :
   (
@@ -84,7 +84,7 @@ Definition maybeFunctor : functor setCategory setCategory := newFunctor
   maybeFIdent
   maybeFComp.
 
-(* This is the "return" natural transformation for maybe. *)
+(* This is the "return" natural transformation for `maybe`. *)
 
 #[local] Theorem maybeEtaNaturality
   (x y : object setCategory)
@@ -103,7 +103,7 @@ Definition maybeEta : naturalTransformation idFunctor maybeFunctor :=
     (@just)
     maybeEtaNaturality.
 
-(* This is the "join" natural transformation for maybe. *)
+(* This is the "join" natural transformation for `maybe`. *)
 
 #[local] Theorem maybeMuNaturality (x y : object setCategory) (f : arrow x y) :
   @compose
@@ -145,7 +145,7 @@ Definition maybeMu :
   )
   maybeMuNaturality.
 
-(* Now we can prove that maybe is a monad. *)
+(* Now we can prove that `maybe` is a monad. *)
 
 #[local] Theorem maybeMAssoc :
   eta (

--- a/proofs/CategoryTheory/Functor.v
+++ b/proofs/CategoryTheory/Functor.v
@@ -12,7 +12,7 @@ Require Import Main.Tactics.
 
 #[local] Set Universe Polymorphism.
 
-(* Metavariables for functors: F, G, H *)
+(* Metavariables for functors: `F`, `G`, `H` *)
 
 Record functor C D := newFunctor {
   oMap : object C -> object D;

--- a/proofs/CategoryTheory/Monad.v
+++ b/proofs/CategoryTheory/Monad.v
@@ -12,7 +12,7 @@ Require Import Main.CategoryTheory.NaturalTransformation.
 
 #[local] Set Universe Polymorphism.
 
-(* Metavariable for monads: M *)
+(* Metavariable for monads: `M` *)
 
 Record monad
   {C}

--- a/proofs/CategoryTheory/NaturalTransformation.v
+++ b/proofs/CategoryTheory/NaturalTransformation.v
@@ -15,7 +15,7 @@ Require Import Main.Tactics.
 
 #[local] Set Universe Polymorphism.
 
-(* Metavariables for natural transformations: Eta, Mu *)
+(* Metavariables for natural transformations: `Eta`, `Mu` *)
 
 Record naturalTransformation {C D} (F G : functor C D) :=
 newNaturalTransformation {

--- a/proofs/CategoryTheory/Object.v
+++ b/proofs/CategoryTheory/Object.v
@@ -50,8 +50,8 @@ Proof.
 Qed.
 
 (*
-  We deliberately avoid adding a resolve hint for isomorphicTrans because doing
-  so could lead to nonterminating searches.
+  We deliberately avoid adding a resolve hint for `isomorphicTrans` because
+  doing so could lead to nonterminating searches.
 *)
 
 Theorem isomorphicSymm C (x y : object C) : isomorphic x y <-> isomorphic y x.
@@ -63,8 +63,8 @@ Proof.
 Qed.
 
 (*
-  We deliberately avoid adding a resolve hint for isomorphicSymm because doing
-  so could lead to nonterminating searches.
+  We deliberately avoid adding a resolve hint for `isomorphicSymm` because
+  doing so could lead to nonterminating searches.
 *)
 
 Theorem opIsomorphic C x y :

--- a/proofs/CategoryTheory/Product.v
+++ b/proofs/CategoryTheory/Product.v
@@ -14,8 +14,8 @@ Require Import Main.Tactics.
 
 #[local] Set Universe Polymorphism.
 
-(* Metavariable for products: xy *)
-(* Metavariables for projections: px, py *)
+(* Metavariable for products: `xy` *)
+(* Metavariables for projections: `px`, `py` *)
 
 Definition product
   {C}
@@ -63,7 +63,7 @@ Proof.
 Qed.
 
 (*
-  We deliberately avoid adding a resolve hint for productCommutator because
+  We deliberately avoid adding a resolve hint for `productCommutator` because
   doing so could lead to nonterminating searches.
 *)
 

--- a/proofs/Kleene/KleeneData.v
+++ b/proofs/Kleene/KleeneData.v
@@ -8,8 +8,8 @@
 
 Module Type KleeneData.
   (*
-    Assumption: Let (T, leq) be a partially ordered set, or poset. A poset is
-    a set with a binary relation which is reflexive, transitive, and
+    Assumption: Let (`T`, `leq`) be a partially ordered set, or poset. A poset
+    is a set with a binary relation that is reflexive, transitive, and
     antisymmetric.
   *)
 
@@ -26,8 +26,8 @@ Module Type KleeneData.
   #[export] Hint Rewrite antisymmetry: main.
 
   (*
-    A supremum of a subset of T is a least element of T which is greater than
-    or equal to every element in the subset. This is also called a join or
+    A supremum of a subset of `T` is a least element of `T` which is greater
+    than or equal to every element in the subset. This is also called a join or
     least upper bound.
   *)
 
@@ -38,7 +38,7 @@ Module Type KleeneData.
   #[export] Hint Unfold supremum : main.
 
   (*
-    A directed subset of T is a non-empty subset of T such that any two
+    A directed subset of `T` is a non-empty subset of `T` such that any two
     elements in the subset have an upper bound in the subset.
   *)
 
@@ -61,7 +61,7 @@ Module Type KleeneData.
   #[export] Hint Resolve directedComplete : main.
 
   (*
-    Assumption: Let T have a least element called bottom. This makes our
+    Assumption: Let `T` have a least element called bottom. This makes our
     partial order a pointed directed-complete partial order.
   *)
 

--- a/proofs/Kleene/KleeneTheorems.v
+++ b/proofs/Kleene/KleeneTheorems.v
@@ -43,7 +43,7 @@ Module KleeneTheorems (Kleene : KleeneData).
 
   #[export] Hint Unfold continuous : main.
 
-  (* This function performs iterated application of a function to bottom. *)
+  (* This function performs iterated application of a function to `bottom`. *)
 
   Fixpoint approx f n :=
     match n with
@@ -70,7 +70,7 @@ Module KleeneTheorems (Kleene : KleeneData).
 
   #[local] Hint Resolve natDiff : main.
 
-  (* The supremum of a subset of T, if it exists, is unique. *)
+  (* The supremum of a subset of `T`, if it exists, is unique. *)
 
   Theorem supremumUniqueness :
     forall P x1 x2,
@@ -96,9 +96,9 @@ Module KleeneTheorems (Kleene : KleeneData).
   #[export] Hint Resolve continuousImpliesMonotone : main.
 
   (*
-    Iterated applications of a monotone function f to bottom form an ω-chain,
-    which means they are a totally ordered subset of T. This ω-chain is called
-    the ascending Kleene chain of f.
+    Iterated applications of a monotone function `f` to bottom form an
+    ω-chain, which means they are a totally ordered subset of `T`. This
+    ω-chain is called the ascending Kleene chain of `f`.
   *)
 
   Theorem omegaChain :
@@ -113,7 +113,7 @@ Module KleeneTheorems (Kleene : KleeneData).
 
   #[export] Hint Resolve omegaChain : main.
 
-  (* The ascending Kleene chain of f is directed. *)
+  (* The ascending Kleene chain of `f` is directed. *)
 
   Theorem kleeneChainDirected :
     forall f,

--- a/proofs/SystemF/LocalClosure.v
+++ b/proofs/SystemF/LocalClosure.v
@@ -75,7 +75,7 @@ Proof.
   clean. apply tlcBoundVar. lia.
 Qed.
 
-(* Don't add a resolve hint because eapply has a hard time guessing i1. *)
+(* Don't add a resolve hint because `eapply` has a hard time guessing `i1`. *)
 
 Theorem eLocalClosureMonotonic :
   forall e ie1 ie2 it1 it2,
@@ -89,4 +89,7 @@ Proof.
     apply tLocalClosureMonotonic with (i1 := nt); magic.
 Qed.
 
-(* Don't add a resolve hint because eapply has a hard time guessing ie1/it1. *)
+(*
+  Don't add a resolve hint because `eapply` has a hard time guessing
+  `ie1`/`it1`.
+*)

--- a/proofs/Tactics.v
+++ b/proofs/Tactics.v
@@ -105,9 +105,9 @@ Ltac clean := let magicTactic := magic in simplify magicTactic; sort.
 Ltac fact E := let H := fresh "H" in pose (H := E); clearbody H.
 
 (*
-  This tactic is useful if you have a hypothesis H : P -> Q and you want to
-  use Q. You can just write `feed H`. A new proof obligation for P may be
-  generated, and then the hypothesis will be specialized to H : Q.
+  This tactic is useful if you have a hypothesis `H : P -> Q` and you want to
+  use `Q`. You can just write `feed H`. A new proof obligation for `P` may be
+  generated, and then the hypothesis will be specialized to `H : Q`.
 *)
 
 Ltac feed H1 :=

--- a/proofs/Tutorial/Lesson0_Intro.v
+++ b/proofs/Tutorial/Lesson0_Intro.v
@@ -47,9 +47,9 @@ Check S (S O). (* nat *)
 
 (* Numeric literals can also be used to construct natural numbers. *)
 
-Check 0. (* Datatypes.nat *)
-Check 1. (* Datatypes.nat *)
-Check 2. (* Datatypes.nat *)
+Check 0. (* `Datatypes.nat` *)
+Check 1. (* `Datatypes.nat` *)
+Check 2. (* `Datatypes.nat` *)
 
 (*
   Recursive definitions use the `Fixpoint` keyword instead of `Definition`.

--- a/proofs/Tutorial/Lesson1_DependentTypes.v
+++ b/proofs/Tutorial/Lesson1_DependentTypes.v
@@ -20,9 +20,9 @@ Inductive slist : nat -> Type :=
 
 (* Let's construct some `slists`. *)
 
-Check snil. (* slist 0 *)
-Check scons "foo" snil. (* slist 1 *)
-Check scons "hello" (scons "world" snil). (* slist 2 *)
+Check snil. (* `slist 0` *)
+Check scons "foo" snil. (* `slist 1` *)
+Check scons "hello" (scons "world" snil). (* `slist 2` *)
 
 (*
   Here's a function which produces an `slist` of a given length containing
@@ -45,8 +45,8 @@ Fixpoint concat {n1 n2}
          (l2 : slist n2) :
          slist (n1 + n2) :=
   match l1 in slist n3
-  return slist (n3 + n2) (* Here, n3 = n1. *)
+  return slist (n3 + n2) (* Here, `n3` = `n1`. *)
   with
-  | snil => l2 (* But n3 = 0 here. *)
-  | scons x l3 => scons x (concat l3 l2) (* And n3 = S (len l3) here. *)
+  | snil => l2 (* But `n3` = `0` here. *)
+  | scons x l3 => scons x (concat l3 l2) (* And `n3` = `S (len l3)` here. *)
   end.

--- a/proofs/Tutorial/Lesson2_Logic.v
+++ b/proofs/Tutorial/Lesson2_Logic.v
@@ -24,7 +24,7 @@ Inductive and P Q : Prop := (* Notation: `P /\ Q` *)
 
 Arguments conj {_} {_}.
 
-(* A proof of True AND True *)
+(* A proof of `True` *and* `True` *)
 
 Definition true_and_true_1 : and True True :=
   conj trivial trivial.
@@ -39,7 +39,7 @@ Proof.
   - apply trivial.
 Qed.
 
-Print true_and_true_2. (* conj trivial trivial *)
+Print true_and_true_2. (* `conj trivial trivial` *)
 
 (* The same proof, but written using the `;` tactical *)
 
@@ -48,9 +48,9 @@ Proof.
   apply conj; apply trivial.
 Qed.
 
-Print true_and_true_3. (* conj trivial trivial *)
+Print true_and_true_3. (* `conj trivial trivial` *)
 
-(* Let's see what happens when we try to prove True AND False. *)
+(* Let's see what happens when we try to prove `True` *and* `False`. *)
 
 Theorem true_and_false : and True False.
 Proof.
@@ -74,7 +74,7 @@ Inductive or P Q : Prop := (* Notation: `P \/ Q` *)
 Arguments orIntroL {_} {_}.
 Arguments orIntroR {_} {_}.
 
-(* Let's prove True OR False. *)
+(* Let's prove `True` *or* `False`. *)
 
 Theorem true_or_false : or True False.
 Proof.
@@ -86,7 +86,7 @@ Qed.
 
 Definition not A := A -> False. (* Notation: ~ A *)
 
-(* A proof of NOT False *)
+(* A proof of *not* `False` *)
 
 Theorem not_false : not False.
 Proof.
@@ -100,11 +100,11 @@ Proof.
   exact H.
 Qed.
 
-Print not_false. (* fun H : False => H *)
+Print not_false. (* `fun H : False => H` *)
 
 (* Propositional equality *)
 
-Inductive eq A (x : A) : A -> Prop := (* Notation: x = x *)
+Inductive eq A (x : A) : A -> Prop := (* Notation: `x = x` *)
 | eq_refl : eq A x x. (* A dependent type! *)
 
 (* Make the `A` argument of `eq_refl` implicit. *)
@@ -129,8 +129,8 @@ Definition leibniz A
                    (y : A)
                    (e : eq A x y) :
                    P y :=
-  match e in eq _ _ z return P z with (* Here, z = y. *)
-  | eq_refl _ => f (* But z = x here. *)
+  match e in eq _ _ z return P z with (* Here, `z` = `y`. *)
+  | eq_refl _ => f (* But `z` = `x` here. *)
   end.
 
 (*
@@ -141,15 +141,19 @@ Definition leibniz A
 Check leibniz.
 
 (*
+  ```
   forall (A : Type) (x : A) (P : A -> Prop),
   P x -> forall y : A, eq A x y -> P y
+  ```
 *)
 
 Check eq_ind.
 
 (*
+  ```
   forall (A : Type) (x : A) (P : A -> Prop),
   P x -> forall y : A, eq A x y -> P y
+  ```
 *)
 
 (*
@@ -157,7 +161,7 @@ Check eq_ind.
   quantification, however, is definable as follows:
 *)
 
-Inductive ex A (P : A -> Prop) : Prop := (* Notation: exists x, P x *)
+Inductive ex A (P : A -> Prop) : Prop := (* Notation: `exists x, P x` *)
   ex_intro : forall x : A, P x -> ex A P.
 
 (* Make the `A` and `P` arguments of `ex_intro` implicit. *)

--- a/proofs/Tutorial/Lesson3_Induction.v
+++ b/proofs/Tutorial/Lesson3_Induction.v
@@ -30,23 +30,27 @@ Abort.
 Print add.
 
 (*
+  ```
   fix add (n m : nat) {struct n} : nat :=
     match n with
     | 0 => m
     | S p => S (add p m)
     end
+  ```
 *)
 
 (*
-  From this, it's clear why 0 + n = n. But how do we prove n + 0 = n? We need
-  induction.
+  From this, it's clear why `0 + n = n`. But how do we prove `n + 0 = n`? We
+  need induction.
 *)
 
 Check nat_ind.
 
 (*
+  ```
   forall P : nat -> Prop,
   P 0 -> (forall n : nat, P n -> P (S n)) -> forall n : nat, P n
+  ```
 *)
 
 (*
@@ -75,6 +79,7 @@ Qed.
 Print n_plus_zero.
 
 (*
+  ```
   fun n : nat => nat_ind
     (fun n0 : nat => n0 + 0 = n0)
     eq_refl
@@ -83,6 +88,7 @@ Print n_plus_zero.
         eq_ind_r (fun n1 : nat => S n1 = S n0) eq_refl IHn
     )
     n
+  ```
 *)
 
 (* Let's prove that addition is associative. *)

--- a/proofs/Tutorial/Lesson4_Reflection.v
+++ b/proofs/Tutorial/Lesson4_Reflection.v
@@ -46,7 +46,7 @@ Ltac reflect b :=
 
 (*
   Two definitions of evenness:
-  1. an inductive proposition
+  1. an inductive predicate
   2. a decision procedure
 *)
 

--- a/proofs/Tutorial/Lesson5_Totality.v
+++ b/proofs/Tutorial/Lesson5_Totality.v
@@ -11,7 +11,9 @@
 (********************************************************)
 
 (*
+  ```
   Fixpoint f (n : nat) : nat := f n.
+  ```
 *)
 
 (***************************************************)
@@ -25,31 +27,35 @@
   Prop : Type_1.
 *)
 
-(* If B : Prop, then A -> B : Prop. *)
+(* If `B : Prop`, then `A -> B : Prop`. *)
 
-Check Set -> True. (* Prop *)
+Check Set -> True. (* `Prop` *)
 
-(* Otherwise, if A, B : Type_i, then A -> B : Type_i. *)
+(* Otherwise, if `A, B : Type_i`, then `A -> B : Type_i`. *)
 
-Check Set -> nat. (* Type@{Set+1} *)
+Check Set -> nat. (* `Type@{Set+1}` *)
 
 (* Here are some identity functions for different universes: *)
 
 Definition idProp (t : Prop) (x : t) := x.
 Definition idSet  (t : Set) (x : t) := x.
 
-(* Because Prop is impredicative, we can apply idProp to itself. *)
+(* Because `Prop` is impredicative, we can apply `idProp` to itself. *)
 
-Check idProp (forall t : Prop, t -> t) idProp. (* forall t : Prop, t -> t *)
+Check idProp (forall t : Prop, t -> t) idProp. (* `forall t : Prop, t -> t` *)
 
 (*
-  But Set (a.k.a. Type_0) is predicative, so we can't apply idSet to itself:
+  But `Set` (a.k.a. `Type_0`) is predicative, so we can't apply `idSet` to
+  itself:
 
+  ```
   Check idSet (forall t : Set, t -> t) idSet.
+  ```
 *)
 
 (*
-  For any i, Type_i is predicative. Let's fix some particular universe level i.
+  For any `i`, `Type_i` is predicative. Let's fix some particular universe
+  level `i`.
 *)
 
 Definition universe := Type.
@@ -59,9 +65,11 @@ Definition universe := Type.
 Definition idUniverse (t : universe) (x : t) := x.
 
 (*
-  Like with idSet, predicativity forbids the following:
+  Like with `idSet`, predicativity forbids the following:
 
+  ```
   Check idUniverse (forall t : universe, t -> t) idUniverse.
+  ```
 *)
 
 (*****************************************************************************)
@@ -72,30 +80,38 @@ Definition idUniverse (t : universe) (x : t) := x.
 (*
   The following is not allowed:
 
+  ```
   Inductive bad :=
   | makeBad : (bad -> bool) -> bad.
+  ```
 
-  Suppose bad were allowed. Consider the following function:
+  Suppose `bad` were allowed. Consider the following function:
 
+  ```
   Definition evil (x : bad) : bool :=
     match x with
     | makeBad f => f x
     end.
+  ```
 
-  We could use evil to construct the following diverging term:
+  We could use `evil` to construct the following diverging term:
 
+  ```
   Definition catastrophe : bool := evil (makeBad evil).
+  ```
 
   Note that this is also rejected:
 
+  ```
   Inductive alsoBad :=
   | makeAlsoBad : ((alsoBad -> bool) -> bool) -> alsoBad.
+  ```
 
-  alsoBad can be used to construct a diverging function in an impredicative
+  `alsoBad` can be used to construct a diverging function in an impredicative
   universe, as demonstrated in this paper:
 
-  Coquand, T., Paulin, C. (1990). Inductively defined types. In: Martin-Löf,
-  P., Mints, G. (eds) COLOG-88. COLOG 1988. Lecture Notes in Computer Science,
-  vol 417. Springer, Berlin, Heidelberg.
-  https://doi.org/10.1007/3-540-52335-9_47
+    Coquand, T., Paulin, C. (1990). Inductively defined types. In: Martin-Löf,
+    P., Mints, G. (eds) COLOG-88. COLOG 1988. Lecture Notes in Computer
+    Science, vol 417. Springer, Berlin, Heidelberg.
+    https://doi.org/10.1007/3-540-52335-9_47
 *)

--- a/proofs/TypeTheory/Church.v
+++ b/proofs/TypeTheory/Church.v
@@ -7,7 +7,7 @@
 (*****************************************************************************)
 (*****************************************************************************)
 
-(* These encodings require an impredicative universe, so we will use Prop. *)
+(* These encodings require an impredicative universe, so we will use `Prop`. *)
 
 Module NonDependentPairsWithNonDependentElimination.
   (*
@@ -72,10 +72,12 @@ Module DependentPairsWithNonDependentElimination.
     fun p => eliminate X Y X (fun x _ => x) p.
 
   (*
+    ```
     Definition second (X : Prop) (Y : X -> Prop) (p : Pair X Y) :
       Y (first X Y p)
-  :=
-    eliminate X Y (Y (first X Y p)) (fun _ y => y) p.
+    :=
+      eliminate X Y (Y (first X Y p)) (fun _ y => y) p.
+    ```
   *)
 
   Parameter second :
@@ -105,10 +107,12 @@ Module NonDependentPairsWithDependentElimination.
   *)
 
   (*
+    ```
     Definition Pair (X Y : Prop) : Prop :=
       forall (Z : Pair X Y -> Prop),
       (forall (x : X) (y : Y), Z (construct X Y x y)) ->
       Z ?.
+    ```
   *)
 End NonDependentPairsWithDependentElimination.
 
@@ -119,9 +123,11 @@ Module DependentPairsWithDependentElimination.
   *)
 
   (*
+    ```
     Definition Pair (X : Prop) (Y : X -> Prop) : Prop :=
       forall (Z : Pair X Y -> Prop),
       (forall (x : X) (y : Y x), Z (construct X Y x y)) ->
       Z ?.
+    ```
   *)
 End DependentPairsWithDependentElimination.

--- a/proofs/TypeTheory/Girard.v
+++ b/proofs/TypeTheory/Girard.v
@@ -55,10 +55,12 @@ Definition bad := (
       one omega (fun (x : universe) => one (tau (sigma x)))
 ).
 
-Check bad. (* exfalso *)
-Check bad False. (* False *)
+Check bad. (* `exfalso` *)
+Check bad False. (* `False` *)
 
 (*
+  ```
   Compute bad.
   Compute bad False.
+  ```
 *)


### PR DESCRIPTION
Use backticks to delimit code-like text.

**Status:** Ready

**Fixes:** N/A