### PR TITLE
Use `intros` instead of `intro` in the tutorial for pedagogical simplicity

### DIFF
--- a/proofs/Tutorial/Lesson3_Logic.v
+++ b/proofs/Tutorial/Lesson3_Logic.v
@@ -211,7 +211,7 @@ Goal forall A, A <-> A.
 Proof.
   intros.
   unfold iff. (* `unfold` replaces a name with its definition. *)
-  split; intro; apply H.
+  split; intros; apply H.
 Qed.
 
 (*


### PR DESCRIPTION
Use `intros` instead of `intro` in the tutorial for pedagogical simplicity.

**Status:** Ready

**Fixes:** N/A