### PR TITLE
Require parenthood to be reflexive in the gigamesh development

### DIFF
--- a/proofs/Gigamesh/Gigamesh.v
+++ b/proofs/Gigamesh/Gigamesh.v
@@ -33,6 +33,12 @@ Module Type Gigamesh.
 
   #[export] Hint Unfold ancestor : main.
 
+  (* Every node is at least its own parent. *)
+
+  Axiom reflexivity : forall n, parent n n.
+
+  #[export] Hint Resolve reflexivity : main.
+
   (*
     For each parent of a node, the parent can reach that node via a path
     through the descendants of the parent.

--- a/proofs/Gigamesh/TrivialGigamesh.v
+++ b/proofs/Gigamesh/TrivialGigamesh.v
@@ -21,18 +21,27 @@ Module TrivialGigamesh <: Gigamesh.
 
   Definition edge (n1 n2 : node) := False.
 
-  Definition parent (p : node) (n : node) := False.
+  Definition parent (p : node) (n : node) := True.
 
   (* Coq requires that we copy this verbatim from `Gigamesh`. *)
   Definition ancestor := clos_refl_trans parent.
 
   #[export] Hint Unfold ancestor : main.
 
+  Theorem reflexivity : forall n, parent n n.
+  Proof.
+    unfold parent.
+    search.
+  Qed.
+
+  #[export] Hint Resolve reflexivity : main.
+
   Theorem connectedness :
     forall p n,
     parent p n ->
     clos_refl_trans (fun n1 n2 => edge n1 n2 /\ ancestor p n2) p n.
   Proof.
+    unfold node.
     search.
   Qed.
 


### PR DESCRIPTION
Require parenthood to be reflexive in the gigamesh development.

**Status:** Ready

**Fixes:** N/A
