### PR TITLE
In order to support call-by-need evaluation, restrict gigameshes such that each node has exactly one parent

### DIFF
--- a/proofs/Gigamesh/GigameshTheorems.v
+++ b/proofs/Gigamesh/GigameshTheorems.v
@@ -35,44 +35,27 @@ Module GigameshTheorems (Graph : Gigamesh).
 
   #[export] Hint Unfold reachable : main.
 
-  (* Parenthood implies reachability. *)
+  (* The root is its own parent. *)
 
-  Theorem parentReach :
-    forall n1 n2, parent n1 n2 -> reachable n1 n2.
-  Proof.
-    clean.
-    assert (
-      clos_refl_trans_n1 (
-        fun n2 n3 : node => edge n2 n3 /\ ancestor n1 n3
-      ) n1 n2
-    ); search.
-    clear H.
-    induction H0; eSearch.
-  Qed.
-
-  #[export] Hint Resolve parentReach : main.
-
-  (* Ancestorship implies reachability. *)
-
-  Theorem ancestorReach :
-    forall n1 n2, ancestor n1 n2 -> reachable n1 n2.
-  Proof.
-    clean.
-    induction H; eSearch.
-  Qed.
-
-  #[export] Hint Resolve ancestorReach : main.
-
-  (* The root is the only node that can be a parent of the root. *)
-
-  Theorem rootParent : forall n, parent n root -> n = root.
+  Theorem rootParent : parent root = root.
   Proof.
     search.
   Qed.
 
   #[export] Hint Resolve rootParent : main.
+  #[export] Hint Rewrite rootParent : main.
 
-  (* The root is the only node that is an ancestor of the root. *)
+  (* The root is the only node which is its own parent. *)
+
+  Theorem selfParent : forall n, n = parent n -> n = root.
+  Proof.
+    clean.
+    induction (rootedness n); search.
+  Qed.
+
+  #[export] Hint Resolve selfParent : main.
+
+  (* The root is the only node which is an ancestor of the root. *)
 
   Theorem ancestorOfRoot : forall n, ancestor n root -> n = root.
   Proof.
@@ -80,4 +63,52 @@ Module GigameshTheorems (Graph : Gigamesh).
   Qed.
 
   #[export] Hint Resolve ancestorOfRoot : main.
+
+  (* The ancestors of a given node are totally ordered. *)
+
+  Theorem ancestorsTotallyOrdered :
+    forall n1 n2 n3,
+    ancestor n1 n3 ->
+    ancestor n2 n3 ->
+    ancestor n1 n2 \/
+    ancestor n2 n1.
+  Proof.
+    clean.
+    assert (clos_refl_trans_n1 (fun n1 n2 => n1 = parent n2) n1 n3); search.
+    induction H1; search.
+    assert (clos_refl_trans_n1 (fun n1 n2 => n1 = parent n2) n2 z); search.
+    destruct H3; search.
+  Qed.
+
+  #[export] Hint Resolve ancestorsTotallyOrdered : main.
+
+  (* Parenthood implies reachability. *)
+
+  Theorem parentReach : forall n, reachable (parent n) n.
+  Proof.
+    clean.
+    remember (parent n).
+    apply clos_rtn1_rt.
+    assert (
+      clos_refl_trans_n1 (fun n1 n2 : node =>
+        edge n1 n2 /\ ancestor n0 n2
+      ) n0 n
+    ); search.
+    clear Heqn0.
+    induction H; eSearch.
+  Qed.
+
+  #[export] Hint Resolve parentReach : main.
+
+  (* Ancestorship implies reachability. *)
+
+  Theorem ancestorReach : forall n1 n2, ancestor n1 n2 -> reachable n1 n2.
+  Proof.
+    clean.
+    induction H; eSearch.
+    clean.
+    search.
+  Qed.
+
+  #[export] Hint Resolve ancestorReach : main.
 End GigameshTheorems.

--- a/proofs/Gigamesh/TrivialGigamesh.v
+++ b/proofs/Gigamesh/TrivialGigamesh.v
@@ -15,6 +15,7 @@ Module TrivialGigamesh <: Gigamesh.
   #[local] Arguments clos_refl_trans {A} _ _ _.
   #[local] Hint Resolve rt_refl : main.
 
+
   Definition node := unit.
 
   #[export] Hint Unfold node : main.
@@ -27,39 +28,21 @@ Module TrivialGigamesh <: Gigamesh.
 
   #[export] Hint Unfold edge : main.
 
-  Definition parent (p : node) (n : node) := True.
+  Definition parent (n : node) := tt.
 
   #[export] Hint Unfold parent : main.
 
   (* Coq requires that we copy this verbatim from `Gigamesh`. *)
-  Definition ancestor := clos_refl_trans parent.
+  Definition ancestor := clos_refl_trans (fun n1 n2 => n1 = parent n2).
 
   #[export] Hint Unfold ancestor : main.
 
-  Theorem reflexivity : forall n, parent n n.
+  Theorem rootedness : forall n, ancestor root n.
   Proof.
     search.
   Qed.
 
-  #[export] Hint Resolve reflexivity : main.
-
-  Theorem connectedness :
-    forall p n,
-    parent p n ->
-    clos_refl_trans (fun n1 n2 => edge n1 n2 /\ ancestor p n2) p n.
-  Proof.
-    search.
-  Qed.
-
-  #[export] Hint Resolve connectedness : main.
-
-  Theorem encapsulation :
-    forall n1 n2, edge n1 n2 -> exists p, ancestor p n1 /\ parent p n2.
-  Proof.
-    search.
-  Qed.
-
-  #[export] Hint Resolve encapsulation : main.
+  #[export] Hint Resolve rootedness : main.
 
   Theorem antisymmetry :
     forall n1 n2, ancestor n1 n2 -> ancestor n2 n1 -> n1 = n2.
@@ -69,12 +52,22 @@ Module TrivialGigamesh <: Gigamesh.
 
   #[export] Hint Resolve antisymmetry : main.
 
-  Theorem rootedness : forall n, ancestor root n.
+  Theorem connectedness :
+    forall n,
+    let p := parent n
+    in clos_refl_trans (fun n1 n2 => edge n1 n2 /\ ancestor p n2) p n.
   Proof.
     search.
   Qed.
 
-  #[export] Hint Resolve rootedness : main.
+  #[export] Hint Resolve connectedness : main.
+
+  Theorem encapsulation : forall n1 n2, edge n1 n2 -> ancestor (parent n2) n1.
+  Proof.
+    search.
+  Qed.
+
+  #[export] Hint Resolve encapsulation : main.
 End TrivialGigamesh.
 
 Module TrivialGigameshTheorems := GigameshTheorems TrivialGigamesh.


### PR DESCRIPTION
In order to support call-by-need evaluation, restrict gigameshes such that each node has exactly one parent.

**Status:** Ready

**Fixes:** N/A