### PR TITLE
Use the word "allowed" instead of "admitted" in the proxy graphs development

### DIFF
--- a/proofs/AdmissibilityGraph/README.md
+++ b/proofs/AdmissibilityGraph/README.md
@@ -143,9 +143,9 @@ The second conclusion would seem to imply that admissibility is reflexive, which
 
 ## Deciding admissibility
 
-We may wish to check whether a dependency graph is compatible with a given admissibility graph containing the same nodes. Let *N* be the number of nodes, let *E* be the number of child-parent relationships, and let *D* be the number of dependencies. Then we can validate the dependency graph in 𝒪(*N*² + *NE*) expected time and 𝒪(*N* + *D*) space in the worst case by defining an auxiliary graph as follows:
+We may wish to check whether a dependency graph is compatible with a given admissibility graph containing the same nodes. Let *N* be the number of nodes, let *E* be the number of child-parent relationships, and let *D* be the number of dependencies. Then we can validate the dependency graph in 𝒪(*N*² + *NE*) expected time and 𝒪(*N* + *D*) space in the worst case by defining an auxiliary graph as the smallest graph satisfying:
 
-- For every node `X` in the admissibility graph, the auxiliary graph will have two nodes `X₁` and `X₂`.
-- For every child-parent relationship `C` → `P`, the auxiliary graph will have two edges `C₁` → `P₁` and `P₁` → `C₂`.
+- For every node `X` in the admissibility graph, the auxiliary graph has two nodes `X₁` and `X₂`.
+- For every child-parent relationship `C` ⭢ `P` in the admissibility graph, the auxiliary graph has two edges `C₁` ⭢ `P₁` and `P₁` ⭢ `C₂`.
 
-Then, to check that a dependency `S` → `T` is admissible, it suffices to check that `T₂` is reachable from `S₁` in the auxiliary graph. This can be done with DFS in 𝒪(*N* + *E*) time and 𝒪(*N*) space. If we traverse all the nodes `T₂` reachable from some source `S₁` (e.g., with a depth-first strategy), we discover all the nodes which admit that source, again in 𝒪(*N* + *E*) time and 𝒪(*N*) space. By doing this for every source `S₁`, we can discover all the admissible dependencies in the admissibility graph. Any dependencies which weren't discovered (which can be recorded by a hash table) aren't admissible.
+Then, to check that a dependency `S` ⭢ `T` is admissible, it suffices to check that `T₂` is reachable from `S₁` in the auxiliary graph. This can be done with DFS in 𝒪(*N* + *E*) time and 𝒪(*N*) space. If we traverse all the nodes `T₂` reachable from some source `S₁` (e.g., with a depth-first strategy), we discover all the nodes which admit that source, again in 𝒪(*N* + *E*) time and 𝒪(*N*) space. By doing this for every source `S₁`, we can discover all the dependencies admitted by the admissibility graph. Any dependencies which weren't discovered (which can be recorded by a hash table) aren't admissible.

--- a/proofs/ProxyGraph/ProxyGraph.v
+++ b/proofs/ProxyGraph/ProxyGraph.v
@@ -39,14 +39,14 @@ Arguments ingress {_} _ _.
   between the nodes should be allowed.
 *)
 
-Inductive admits {node} (g : proxyGraph node) (n : node) : node -> Prop :=
-| reflexivity : admits g n n
+Inductive allowed {node} (g : proxyGraph node) (n : node) : node -> Prop :=
+| reflexivity : allowed g n n
 | egressExtension :
-    forall n1 n2, egress g n n1 -> admits g n1 n2 -> admits g n n2
+    forall n1 n2, egress g n n1 -> allowed g n1 n2 -> allowed g n n2
 | ingressExtension :
-    forall n1 n2, admits g n n1 -> ingress g n1 n2 -> admits g n n2.
+    forall n1 n2, allowed g n n1 -> ingress g n1 n2 -> allowed g n n2.
 
-#[export] Hint Constructors admits : main.
+#[export] Hint Constructors allowed : main.
 
 (*
   The following theorem gives an equivalent way to characterize which
@@ -55,7 +55,7 @@ Inductive admits {node} (g : proxyGraph node) (n : node) : node -> Prop :=
 
 Theorem admission :
   forall (node : Type) (g : proxyGraph node) n1 n2,
-  admits g n1 n2 <->
+  allowed g n1 n2 <->
   exists n3,
     clos_refl_trans (egress g) n1 n3 /\ clos_refl_trans (ingress g) n3 n2.
 Proof.
@@ -80,7 +80,7 @@ Theorem duality :
   forall (node : Type) (g1 g2 : proxyGraph node),
   (forall n1 n2, egress g1 n1 n2 -> ingress g2 n2 n1) ->
   (forall n1 n2, ingress g1 n1 n2 -> egress g2 n2 n1) ->
-  forall n1 n2, admits g1 n1 n2 -> admits g2 n2 n1.
+  forall n1 n2, allowed g1 n1 n2 -> allowed g2 n2 n1.
 Proof.
   clean.
   destruct (admission node g1 n1 n2).

--- a/proofs/ProxyGraph/README.md
+++ b/proofs/ProxyGraph/README.md
@@ -1,27 +1,37 @@
 # Proxy graphs
 
-A *proxy graph* is a specification for which dependencies should be allowed between components in a system. It can be understood as a more general and lower level form of [admissibility graph](https://github.com/stepchowfun/proofs/tree/main/proofs/AdmissibilityGraph). Proxy graphs can encode patterns such as encapsulation and sandboxing.
+A *proxy graph* is a specification for which dependencies should be allowed between components in a system. Proxy graphs can encode patterns such as encapsulation and sandboxing, and they can be understood as a generalization of [admissibility graphs](https://github.com/stepchowfun/proofs/tree/main/proofs/AdmissibilityGraph).
 
 ## Definition
 
 The nodes are the components of the system. There are two types of directed edges:
 
-1. Egress extension: X ⭢ₑ Y
-2. Ingress extension: X ⭢ᵢ Y
+1. Egress extension: `X` ⭢ₑ `Y`
+2. Ingress extension: `X` ⭢ᵢ `Y`
 
 The following axioms determine which dependencies are allowed.
 
 1. Every node is allowed to depend on itself.
-3. If there is an edge X ⭢ₑ Y and Y is allowed to depend on Z, then X is allowed to depend on Z.
-2. If X is allowed to depend on Y and there is an edge Y ⭢ᵢ Z, then X is allowed to depend on Z.
+3. If there is an edge `X` ⭢ₑ `Y` and `Y` is allowed to depend on `Z`, then `X` is allowed to depend on `Z`.
+2. If `X` is allowed to depend on `Y` and there is an edge `Y` ⭢ᵢ `Z`, then `X` is allowed to depend on `Z`.
 4. No other dependencies are allowed.
 
-Given an edge X ⭢ₑ Y, Y can be understood as a forward proxy in front of X. Likewise, given an edge X ⭢ᵢ Y, X can be understood as a reverse proxy in front of Y. These analogies are where the name "proxy graph" comes from.
+Given an edge `X` ⭢ₑ `Y`, `Y` can be understood as a forward proxy in front of `X`. Likewise, given an edge `X` ⭢ᵢ `Y`, `X` can be understood as a reverse proxy in front of `Y`. These analogies are where the name "proxy graph" comes from.
 
 ## Theorems
 
 This development contains verified proofs of the following two theorems:
 
-**Theorem (admission).** X is allowed to depend on Y iff there is a path of ⭢ₑ edges from X to some Z followed by a path of Y ⭢ᵢ Z edges from Z to Y.
+**Theorem (admission).** `X` is allowed to depend on `Y` iff there is a path of ⭢ₑ edges from `X` to some `Z` followed by a path of `Y` ⭢ᵢ `Z` edges from `Z` to `Y`.
 
-**Theorem (duality).** Given two proxy graphs G₁ and G₂ with the same set of nodes such that edges X ⭢ᵢ Y in G₁ imply edges Y ⭢ₑ X in G₂ and edges X ⭢ₑ Y in G₁ imply edges Y ⭢ᵢ X in G₂, then if G₁ allows some X to depend on some Y, G₂ allows Y to depend on X.
+**Theorem (duality).** Given two proxy graphs `G₁` and `G₂` with the same set of nodes such that edges `X` ⭢ᵢ `Y` in `G₁` imply edges `Y` ⭢ₑ `X` in `G₂` and edges `X` ⭢ₑ `Y` in `G₁` imply edges `Y` ⭢ᵢ `X` in `G₂`, then if `G₁` allows some `X` to depend on some `Y`, `G₂` allows `Y` to depend on `X`.
+
+## An algorithm to validate dependencies
+
+We may wish to check whether a dependency graph is compatible with a given proxy graph containing the same nodes. Let *N* be the number of nodes, let *E* be the number of edges, and let *D* be the number of dependencies. Then we can validate the dependency graph in 𝒪(*N*² + *NE*) expected time and 𝒪(*N* + *D*) space in the worst case by defining an auxiliary graph as the smallest graph satisfying:
+
+- For every node `X` in the proxy graph, the auxiliary graph has two nodes `Xₑ` and `Xᵢ` and an edge `Xₑ` ⭢ `Xᵢ`.
+- For every edge `X` ⭢ₑ `Y` in the proxy graph, the auxiliary graph has an edge `Xₑ` ⭢ `Yₑ`.
+- For every edge `X` ⭢ᵢ `Y` in the proxy graph, the auxiliary graph has an edge `Xᵢ` ⭢ `Yᵢ`.
+
+Then, to check that a dependency `X` ⭢ `Y` is allowed, it suffices to check that `Yᵢ` is reachable from `Xₑ` in the auxiliary graph. This can be done with DFS in 𝒪(*N* + *E*) time and 𝒪(*N*) space. If we traverse all the nodes `Yᵢ` reachable from some source `Xₑ` (e.g., with a depth-first strategy), we discover all the nodes which that source is allowed to depend on, again in 𝒪(*N* + *E*) time and 𝒪(*N*) space. By doing this for every source `Xₑ`, we can discover all the dependencies allowed by the proxy graph. Any dependencies which weren't discovered (which can be recorded by a hash table) aren't allowed.


### PR DESCRIPTION
Use the word "allowed" instead of "admitted" in the proxy graphs development.

**Status:** Ready

**Fixes:** N/A