### PR TITLE
Use type inference to simplify a definition

### DIFF
--- a/proofs/CategoryTheory/Equivalence.v
+++ b/proofs/CategoryTheory/Equivalence.v
@@ -21,13 +21,7 @@ Definition equivalence C D
   (Mu : naturalTransformation (idFunctor D) (compFunctor G F)) :=
   naturalIsomorphism Eta /\ naturalIsomorphism Mu.
 
-Definition equivalent C D :=
-  exists
-    (F : functor C D)
-    (G : functor D C)
-    (Eta : naturalTransformation (compFunctor F G) (idFunctor C))
-    (Mu : naturalTransformation (idFunctor D) (compFunctor G F)),
-  equivalence C D F G Eta Mu.
+Definition equivalent C D := exists F G Eta Mu, equivalence C D F G Eta Mu.
 
 Theorem equivalentRefl C : equivalent C C.
 Proof.

--- a/proofs/CategoryTheory/Examples/Set.v
+++ b/proofs/CategoryTheory/Examples/Set.v
@@ -26,14 +26,14 @@ Program Definition setCategory : category := {|
 
 (* Cartesian products are categorical products in this category. *)
 
-Theorem cartesianProduct x y :
-  @product setCategory x y (x * y) fst snd.
+Theorem cartesianProduct x y : @product setCategory x y (x * y) fst snd.
 Proof.
   unfold product.
   clean.
   unfold universal.
   split.
-  - exists (fun w => (qx w, qy w)). search.
+  - exists (fun w => (qx w, qy w)).
+    search.
   - unfold arrowUnique.
     intros.
     destruct H.


### PR DESCRIPTION
Use type inference to simplify a definition.

**Status:** Ready

**Fixes:** N/A