### PR TITLE
Use `[` and `]` instead of `{` and `}` for implicit arguments

### DIFF
--- a/proofs/AdmissibilityGraph/AdmissibilityGraph.v
+++ b/proofs/AdmissibilityGraph/AdmissibilityGraph.v
@@ -10,9 +10,9 @@ Require Import Coq.Relations.Operators_Properties.
 Require Import Coq.Relations.Relation_Operators.
 Require Import Main.Tactics.
 
-#[local] Arguments clos_refl_trans {A} _ _ _.
-#[local] Arguments clos_refl_trans_1n {A} _ _ _.
-#[local] Arguments clos_refl_trans_n1 {A} _ _ _.
+#[local] Arguments clos_refl_trans [A] _ _ _.
+#[local] Arguments clos_refl_trans_1n [A] _ _ _.
+#[local] Arguments clos_refl_trans_n1 [A] _ _ _.
 #[local] Hint Constructors clos_refl_trans : main.
 #[local] Hint Constructors clos_refl_trans_1n : main.
 #[local] Hint Constructors clos_refl_trans_n1 : main.
@@ -31,8 +31,8 @@ Record admissibilityGraph (node : Type) := {
   exports : node -> node -> Prop;
 }.
 
-Arguments trusts {_} _ _.
-Arguments exports {_} _ _.
+Arguments trusts [_] _ _.
+Arguments exports [_] _ _.
 
 (*
   Every node may depend on itself, the nodes it trusts, the nodes that export
@@ -40,7 +40,7 @@ Arguments exports {_} _ _.
   exported by a node that it can depend on.
 *)
 
-Inductive allowed {node} (g : admissibilityGraph node) (n : node) : node
+Inductive allowed [node] (g : admissibilityGraph node) (n : node) : node
   -> Prop :=
 | loop : allowed g n n
 | trust : forall n1, trusts g n n1 -> allowed g n n1

--- a/proofs/CategoryTheory/Arrow.v
+++ b/proofs/CategoryTheory/Arrow.v
@@ -13,39 +13,39 @@ Require Import Main.Tactics.
 
 #[local] Set Universe Polymorphism.
 
-Definition endomorphism {C} x := @arrow C x x.
+Definition endomorphism [C] x := @arrow C x x.
 
-Definition arrowExists {C} {x y : object C} (P : arrow x y -> Prop) :=
+Definition arrowExists [C] [x y : object C] (P : arrow x y -> Prop) :=
   exists f, P f.
 
-Definition arrowUnique {C} {x y : object C} (P : arrow x y -> Prop) :=
+Definition arrowUnique [C] [x y : object C] (P : arrow x y -> Prop) :=
   forall f g, P f -> P g -> f = g.
 
-Definition universal {C} {x y : object C} (P : arrow x y -> Prop) :=
+Definition universal [C] [x y : object C] (P : arrow x y -> Prop) :=
   arrowExists P /\ arrowUnique P.
 
-Definition inverse {C} {x y : object C} (f : arrow x y) (g : arrow y x) :=
+Definition inverse [C] [x y : object C] (f : arrow x y) (g : arrow y x) :=
   compose f g = id x /\ compose g f = id y.
 
-Definition epimorphism {C} {x y : object C} (f : arrow x y) :=
+Definition epimorphism [C] [x y : object C] (f : arrow x y) :=
   forall z (g h : arrow y z), compose f g = compose f h -> g = h.
 
-Definition monomorphism {C} {x y : object C} (f : arrow x y) :=
+Definition monomorphism [C] [x y : object C] (f : arrow x y) :=
   forall z (g h : arrow z x), compose g f = compose h f -> g = h.
 
-Definition isomorphism {C} {x y : object C} (f : arrow x y) :=
+Definition isomorphism [C] [x y : object C] (f : arrow x y) :=
   exists g, inverse f g.
 
-Definition automorphism {C} {x : object C} (f : endomorphism x) :=
+Definition automorphism [C] [x : object C] (f : endomorphism x) :=
   isomorphism f.
 
-Definition retraction {C} {x y : object C} (f : arrow x y) :=
+Definition retraction [C] [x y : object C] (f : arrow x y) :=
   exists g, compose g f = id y.
 
-Definition section {C} {x y : object C} (f : arrow x y) :=
+Definition section [C] [x y : object C] (f : arrow x y) :=
   exists g, compose f g = id x.
 
-Theorem opIsomorphism {C x y} f :
+Theorem opIsomorphism [C x y] f :
   @isomorphism C x y f <-> @isomorphism (oppositeCategory C) y x f.
 Proof.
   unfold isomorphism.
@@ -55,7 +55,7 @@ Qed.
 
 #[export] Hint Resolve opIsomorphism : main.
 
-Theorem opMonoEpi {C x y} f :
+Theorem opMonoEpi [C x y] f :
   @monomorphism C x y f <-> @epimorphism (oppositeCategory C) y x f.
 Proof.
   search.
@@ -63,7 +63,7 @@ Qed.
 
 #[export] Hint Resolve opMonoEpi : main.
 
-Theorem opEpiMono {C x y} f :
+Theorem opEpiMono [C x y] f :
   @epimorphism C x y f <-> @monomorphism (oppositeCategory C) y x f.
 Proof.
   search.
@@ -71,7 +71,7 @@ Qed.
 
 #[export] Hint Resolve opEpiMono : main.
 
-Theorem opRetSec {C x y} f :
+Theorem opRetSec [C x y] f :
   @retraction C x y f <-> @section (oppositeCategory C) y x f.
 Proof.
   search.
@@ -79,7 +79,7 @@ Qed.
 
 #[export] Hint Resolve opRetSec : main.
 
-Theorem opSecRet {C x y} f :
+Theorem opSecRet [C x y] f :
   @section C x y f <-> @retraction (oppositeCategory C) y x f.
 Proof.
   search.
@@ -87,7 +87,7 @@ Qed.
 
 #[export] Hint Resolve opSecRet : main.
 
-Theorem idIso {C} x : isomorphism (@id C x).
+Theorem idIso [C] x : isomorphism (@id C x).
 Proof.
   unfold isomorphism.
   exists (id x).
@@ -97,7 +97,7 @@ Qed.
 
 #[export] Hint Resolve idIso : main.
 
-Theorem leftIdUnique {C} (x : object C):
+Theorem leftIdUnique [C] (x : object C):
   arrowUnique (
     fun (f : arrow x x) => forall y (g : arrow x y), compose f g = g
   ).
@@ -111,7 +111,7 @@ Qed.
 
 #[export] Hint Resolve leftIdUnique : main.
 
-Theorem rightIdUnique {C} (x : object C):
+Theorem rightIdUnique [C] (x : object C):
   arrowUnique (
     fun (f : arrow x x) => forall y (g : arrow y x), compose g f = g
   ).
@@ -125,7 +125,7 @@ Qed.
 
 #[export] Hint Resolve rightIdUnique : main.
 
-Theorem inverseUnique {C} {x y : object C} (f : arrow x y) :
+Theorem inverseUnique [C] [x y : object C] (f : arrow x y) :
   arrowUnique (inverse f).
 Proof.
   unfold arrowUnique.
@@ -139,7 +139,7 @@ Qed.
 
 #[export] Hint Resolve inverseUnique : main.
 
-Theorem inverseInvolution {C} {x y : object C} (f h : arrow x y) g :
+Theorem inverseInvolution [C] [x y : object C] (f h : arrow x y) g :
   inverse f g -> inverse g h -> f = h.
 Proof.
   unfold inverse.
@@ -152,7 +152,7 @@ Qed.
 
 #[export] Hint Resolve inverseInvolution : main.
 
-Theorem isoImpliesEpi {C x y} f : @isomorphism C x y f -> @epimorphism C x y f.
+Theorem isoImpliesEpi [C x y] f : @isomorphism C x y f -> @epimorphism C x y f.
 Proof.
   unfold isomorphism.
   unfold epimorphism.
@@ -168,7 +168,7 @@ Qed.
 
 #[export] Hint Resolve isoImpliesEpi : main.
 
-Theorem isoImpliesMono {C x y} f :
+Theorem isoImpliesMono [C x y] f :
   @isomorphism C x y f -> @monomorphism C x y f.
 Proof.
   clean.
@@ -180,7 +180,7 @@ Qed.
 
 #[export] Hint Resolve isoImpliesMono : main.
 
-Theorem secImpliesMono {C x y} f : @section C x y f -> @monomorphism C x y f.
+Theorem secImpliesMono [C x y] f : @section C x y f -> @monomorphism C x y f.
 Proof.
   unfold section.
   unfold monomorphism.
@@ -195,7 +195,7 @@ Qed.
 
 #[export] Hint Resolve secImpliesMono : main.
 
-Theorem retImpliesEpi {C x y} f : @retraction C x y f -> @epimorphism C x y f.
+Theorem retImpliesEpi [C x y] f : @retraction C x y f -> @epimorphism C x y f.
 Proof.
   clean.
   rewrite opRetSec in H.
@@ -205,7 +205,7 @@ Qed.
 
 #[export] Hint Resolve retImpliesEpi : main.
 
-Theorem monoRetEquivIso {C x y} f :
+Theorem monoRetEquivIso [C x y] f :
   @monomorphism C x y f /\ @retraction C x y f <-> @isomorphism C x y f.
 Proof.
   unfold monomorphism.
@@ -232,7 +232,7 @@ Qed.
 
 #[export] Hint Resolve monoRetEquivIso : main.
 
-Theorem epiSecEquivIso {C x y} f :
+Theorem epiSecEquivIso [C x y] f :
   @epimorphism C x y f /\ @section C x y f <-> @isomorphism C x y f.
 Proof.
   clean.

--- a/proofs/CategoryTheory/Category.v
+++ b/proofs/CategoryTheory/Category.v
@@ -18,7 +18,7 @@ Record isCategory
   (object : Type) (* Objects: `w`, `x`, `y`, `z` *)
   (arrow : object -> object -> Type) (* Arrows: `f`, `g`, `h` *)
   (id : forall x, arrow x x)
-  (compose : forall {x y z}, arrow x y -> arrow y z -> arrow x z)
+  (compose : forall [x y z], arrow x y -> arrow y z -> arrow x z)
 := {
   isCIdentLeft x y (f : arrow x y) : compose (id x) f = f;
   isCIdentRight x y (f : arrow x y) : compose f (id y) = f;
@@ -26,9 +26,9 @@ Record isCategory
     compose (compose f g) h = compose f (compose g h);
 }.
 
-Arguments isCIdentLeft {_ _ _ _ _ _ _} _.
-Arguments isCIdentRight {_ _ _ _ _ _ _} _.
-Arguments isCAssoc {_ _ _ _ _ _ _ _ _} _ _ _.
+Arguments isCIdentLeft [_ _ _ _ _ _ _] _.
+Arguments isCIdentRight [_ _ _ _ _ _ _] _.
+Arguments isCAssoc [_ _ _ _ _ _ _ _ _] _ _ _.
 
 #[export] Hint Constructors isCategory : main.
 
@@ -37,21 +37,21 @@ Record category := {
   categoryLaws : isCategory object arrow id compose;
 }.
 
-Arguments arrow {_} _ _.
-Arguments id {_} _.
-Arguments compose {_ _ _ _} _ _.
+Arguments arrow [_] _ _.
+Arguments id [_] _.
+Arguments compose [_ _ _ _] _ _.
 
-Definition cIdentLeft {C : category} {x y : object C} (f : arrow x y) :
+Definition cIdentLeft [C : category] [x y : object C] (f : arrow x y) :
   compose (id x) f = f
 := C.(categoryLaws).(isCIdentLeft) f.
 
-Definition cIdentRight {C : category} {x y : object C} (f : arrow x y) :
+Definition cIdentRight [C : category] [x y : object C] (f : arrow x y) :
   compose f (id y) = f
 := C.(categoryLaws).(isCIdentRight) f.
 
 Definition cAssoc
-  {C : category}
-  {w x y z : object C}
+  [C : category]
+  [w x y z : object C]
   (f : arrow w x)
   (g : arrow x y)
   (h : arrow y z) :

--- a/proofs/CategoryTheory/Coproduct.v
+++ b/proofs/CategoryTheory/Coproduct.v
@@ -21,7 +21,7 @@ Require Import Main.Tactics.
 (* Metavariables for injections: `ix`, `iy` *)
 
 Definition coproduct
-  {C}
+  [C]
   (x y xy : object C)
   (ix : arrow x xy)
   (iy : arrow y xy)
@@ -59,7 +59,7 @@ Qed.
 #[export] Hint Resolve coproductUnique : main.
 
 Theorem coproductCommutator
-  {C}
+  [C]
   (x y xy : object C)
   (ix : arrow x xy)
   (iy : arrow y xy)
@@ -75,7 +75,7 @@ Qed.
 *)
 
 Theorem coproductCommutative
-  {C}
+  [C]
   (x y xy yx : object C)
   (ix1 : arrow x xy)
   (iy1 : arrow y xy)
@@ -91,7 +91,7 @@ Qed.
 #[export] Hint Resolve coproductCommutative : main.
 
 Theorem coproductAssociative
-  {C}
+  [C]
   (x y z xy yz xy_z x_yz : object C)
   (x_to_xy : arrow x xy)
   (y_to_xy : arrow y xy)
@@ -115,7 +115,7 @@ Qed.
 #[export] Hint Resolve coproductAssociative : main.
 
 Theorem coproductInitial
-  {C}
+  [C]
   (x y xy : object C)
   (x_to_xy : arrow x xy)
   (y_to_xy : arrow y xy)

--- a/proofs/CategoryTheory/Examples/Cat.v
+++ b/proofs/CategoryTheory/Examples/Cat.v
@@ -16,5 +16,5 @@ Program Definition catCategory : category := {|
   object := category;
   arrow := functor;
   id := idFunctor;
-  compose _ _ _ := compFunctor;
+  compose := compFunctor;
 |}.

--- a/proofs/CategoryTheory/Examples/Maybe.v
+++ b/proofs/CategoryTheory/Examples/Maybe.v
@@ -21,8 +21,7 @@ Inductive maybe x : Type :=
 | nothing : maybe x
 | just : x -> maybe x.
 
-Arguments nothing {_}.
-Arguments just {_}.
+Arguments just [_].
 
 (* `maybe` is a functor. *)
 
@@ -30,7 +29,7 @@ Program Definition maybeFunctor : functor setCategory setCategory := {|
   oMap o := maybe o;
   fMap _ _ f := fun e =>
     match e with
-    | nothing => nothing
+    | nothing _ => nothing _
     | just e => just (f e)
     end;
 |}.
@@ -61,7 +60,7 @@ Program Definition maybeMu :
   eta x :=
     fun e1 =>
       match e1 with
-      | nothing => nothing
+      | nothing _ => nothing _
       | just e2 => e2
       end
 |}.

--- a/proofs/CategoryTheory/Functor.v
+++ b/proofs/CategoryTheory/Functor.v
@@ -17,17 +17,17 @@ Require Import Main.Tactics.
 
 Record functor C D := {
   oMap : object C -> object D;
-  fMap {x y} : arrow x y -> arrow (oMap x) (oMap y);
+  fMap [x y] : arrow x y -> arrow (oMap x) (oMap y);
 
   fIdent x : fMap (id x) = id (oMap x);
-  fComp {x y z} (f : arrow x y) (g : arrow y z) :
+  fComp [x y z] (f : arrow x y) (g : arrow y z) :
     compose (fMap f) (fMap g) = fMap (compose f g);
 }.
 
-Arguments oMap {_ _} _.
-Arguments fMap {_ _} _ {_ _} _.
-Arguments fIdent {_ _} _ _.
-Arguments fComp {_ _} _ {_ _ _} _ _.
+Arguments oMap [_ _] _.
+Arguments fMap [_ _] _ [_ _] _.
+Arguments fIdent [_ _] _ _.
+Arguments fComp [_ _] _ [_ _ _] _ _.
 
 #[export] Hint Resolve fIdent : main.
 #[export] Hint Rewrite @fIdent : main.
@@ -41,14 +41,14 @@ Program Definition idFunctor C : endofunctor C := {|
   fMap _ _ f := f;
 |}.
 
-Program Definition compFunctor {C D E} (F : functor C D) (G : functor D E) :
+Program Definition compFunctor [C D E] (F : functor C D) (G : functor D E) :
   functor C E
 := {|
   oMap o := oMap G (oMap F o);
   fMap _ _ f := fMap G (fMap F f);
 |}.
 
-Theorem compFunctorIdentLeft {C D} (F : functor C D) :
+Theorem compFunctorIdentLeft [C D] (F : functor C D) :
   compFunctor (idFunctor C) F = F.
 Proof.
   unfold compFunctor.
@@ -58,7 +58,7 @@ Qed.
 
 #[export] Hint Resolve compFunctorIdentLeft : main.
 
-Theorem compFunctorIdentRight {C D} (F : functor C D) :
+Theorem compFunctorIdentRight [C D] (F : functor C D) :
   compFunctor F (idFunctor D) = F.
 Proof.
   unfold compFunctor.
@@ -69,7 +69,7 @@ Qed.
 #[export] Hint Resolve compFunctorIdentRight : main.
 
 Theorem compFunctorAssoc
-  {B C D E}
+  [B C D E]
   (F : functor B C)
   (G : functor C D)
   (H : functor D E)

--- a/proofs/CategoryTheory/Initial.v
+++ b/proofs/CategoryTheory/Initial.v
@@ -13,7 +13,7 @@ Require Import Main.Tactics.
 
 #[local] Set Universe Polymorphism.
 
-Definition initial {C} (x : object C) :=
+Definition initial [C] (x : object C) :=
   forall y, exists f, forall (g : arrow x y), f = g.
 
 Theorem initialUnique C : uniqueUpToIsomorphism (@initial C).

--- a/proofs/CategoryTheory/Monad.v
+++ b/proofs/CategoryTheory/Monad.v
@@ -15,8 +15,8 @@ Require Import Main.CategoryTheory.NaturalTransformation.
 (* Metavariable for monads: `M` *)
 
 Record monad
-  {C}
-  {F : endofunctor C}
+  [C]
+  [F : endofunctor C]
   (Eta : naturalTransformation (idFunctor C) F)
   (Mu : naturalTransformation (compFunctor F F) F)
 := {
@@ -31,9 +31,9 @@ Record monad
     eta (idNaturalTransformation F);
 }.
 
-Arguments mAssoc {_ _ _ _} _.
-Arguments mIdent1 {_ _ _ _} _.
-Arguments mIdent2 {_ _ _ _} _.
+Arguments mAssoc [_ _ _ _] _.
+Arguments mIdent1 [_ _ _ _] _.
+Arguments mIdent2 [_ _ _ _] _.
 
 #[export] Hint Resolve mAssoc : main.
 #[export] Hint Resolve mIdent1 : main.
@@ -42,8 +42,8 @@ Arguments mIdent2 {_ _ _ _} _.
 #[export] Hint Rewrite @mIdent2 : main.
 
 Theorem eqMonad
-  {C}
-  {F : endofunctor C}
+  [C]
+  [F : endofunctor C]
   (Eta : naturalTransformation (idFunctor C) F)
   (Mu : naturalTransformation (compFunctor F F) F)
   (M1 M2 : monad Eta Mu)

--- a/proofs/CategoryTheory/NaturalTransformation.v
+++ b/proofs/CategoryTheory/NaturalTransformation.v
@@ -18,21 +18,21 @@ Require Import Main.Tactics.
 
 (* Metavariables for natural transformations: `Eta`, `Mu` *)
 
-Record naturalTransformation {C D} (F G : functor C D) := {
+Record naturalTransformation [C D] (F G : functor C D) := {
   eta x : arrow (oMap F x) (oMap G x);
 
-  naturality {x y} (f : arrow x y) :
+  naturality [x y] (f : arrow x y) :
     compose (fMap F f) (eta y) = compose (eta x) (fMap G f);
 }.
 
-Arguments eta {_ _ _ _} _ _.
-Arguments naturality {_ _ _ _} _ {_ _} _.
+Arguments eta [_ _ _ _] _ _.
+Arguments naturality [_ _ _ _] _ [_ _] _.
 
 #[export] Hint Resolve naturality : main.
 #[export] Hint Rewrite @naturality : main.
 
 Theorem eqNaturalTransformation
-  {C D}
+  [C D]
   (F G : functor C D)
   (Eta Mu : naturalTransformation F G)
 : eta Eta = eta Mu -> Eta = Mu.
@@ -58,9 +58,9 @@ Qed.
 #[export] Hint Resolve eqNaturalTransformation : main.
 
 Program Definition leftWhisker
-  {C D E}
+  [C D E]
   (F : functor C D)
-  {G H : functor D E}
+  [G H : functor D E]
   (Eta : naturalTransformation G H) :
   naturalTransformation (compFunctor F G) (compFunctor F H)
 := {|
@@ -68,8 +68,8 @@ Program Definition leftWhisker
 |}.
 
 Program Definition rightWhisker
-  {C D E}
-  {F G : functor C D}
+  [C D E]
+  [F G : functor C D]
   (Eta : naturalTransformation F G)
   (H : functor D E) :
   naturalTransformation (compFunctor F H) (compFunctor G H)
@@ -78,7 +78,7 @@ Program Definition rightWhisker
 |}.
 
 Program Definition idNaturalTransformation
-  {C D}
+  [C D]
   (F : functor C D) :
   naturalTransformation F F
 := {|
@@ -86,8 +86,8 @@ Program Definition idNaturalTransformation
 |}.
 
 Program Definition vertCompNaturalTransformation
-  {C D}
-  {F G H : functor C D}
+  [C D]
+  [F G H : functor C D]
   (Eta : naturalTransformation F G)
   (Mu : naturalTransformation G H) :
   naturalTransformation F H
@@ -105,18 +105,18 @@ Next Obligation.
 Qed.
 
 Definition horCompNaturalTransformation
-  {C D E}
-  {F G : functor C D}
-  {H K : functor D E}
+  [C D E]
+  [F G : functor C D]
+  [H K : functor D E]
   (Alpha : naturalTransformation F G)
   (Beta : naturalTransformation H K) :
   naturalTransformation (compFunctor F H) (compFunctor G K)
 := vertCompNaturalTransformation (rightWhisker Alpha H) (leftWhisker G Beta).
 
 Theorem horCompNaturalTransformationAlt
-  {C D E}
-  {F G : functor C D}
-  {H K : functor D E}
+  [C D E]
+  [F G : functor C D]
+  [H K : functor D E]
   (Alpha : naturalTransformation F G)
   (Beta : naturalTransformation H K)
 : horCompNaturalTransformation Alpha Beta =
@@ -133,6 +133,6 @@ Qed.
 #[export] Hint Resolve horCompNaturalTransformationAlt : main.
 
 Definition naturalIsomorphism
-  {C D} {F G : functor C D}
+  [C D] [F G : functor C D]
   (Eta : naturalTransformation F G)
 := forall x, isomorphism (eta Eta x).

--- a/proofs/CategoryTheory/Object.v
+++ b/proofs/CategoryTheory/Object.v
@@ -13,13 +13,13 @@ Require Import Main.Tactics.
 
 #[local] Set Universe Polymorphism.
 
-Definition isomorphic {C} (x y : object C) :=
+Definition isomorphic [C] (x y : object C) :=
   exists (f : arrow x y), isomorphism f.
 
-Definition uniqueUpToIsomorphism {C} (P : object C -> Prop) :=
+Definition uniqueUpToIsomorphism [C] (P : object C -> Prop) :=
   forall x y, P x -> P y -> isomorphic x y.
 
-Theorem isomorphicRefl {C} (x : object C) : isomorphic x x.
+Theorem isomorphicRefl [C] (x : object C) : isomorphic x x.
 Proof.
   unfold isomorphic.
   unfold isomorphism.
@@ -29,7 +29,7 @@ Qed.
 
 #[export] Hint Resolve isomorphicRefl : main.
 
-Theorem isomorphicTrans {C} (x y z : object C) :
+Theorem isomorphicTrans [C] (x y z : object C) :
   isomorphic x y -> isomorphic y z -> isomorphic x z.
 Proof.
   unfold isomorphic.
@@ -54,7 +54,7 @@ Qed.
   doing so could lead to nonterminating searches.
 *)
 
-Theorem isomorphicSymm {C} (x y : object C) :
+Theorem isomorphicSymm [C] (x y : object C) :
   isomorphic x y <-> isomorphic y x.
 Proof.
   unfold isomorphic.
@@ -68,7 +68,7 @@ Qed.
   doing so could lead to nonterminating searches.
 *)
 
-Theorem opIsomorphic {C} x y :
+Theorem opIsomorphic [C] x y :
   @isomorphic C x y <-> @isomorphic (oppositeCategory C) y x.
 Proof.
   unfold isomorphic.

--- a/proofs/CategoryTheory/Product.v
+++ b/proofs/CategoryTheory/Product.v
@@ -18,7 +18,7 @@ Require Import Main.Tactics.
 (* Metavariables for projections: `px`, `py` *)
 
 Definition product
-  {C}
+  [C]
   (x y xy : object C)
   (px : arrow xy x)
   (py : arrow xy y)
@@ -50,7 +50,7 @@ Qed.
 #[export] Hint Resolve productUnique : main.
 
 Theorem productCommutator
-  {C}
+  [C]
   (x y xy : object C)
   (px : arrow xy x)
   (py : arrow xy y)
@@ -71,7 +71,7 @@ Qed.
 *)
 
 Theorem productCommutative
-  {C}
+  [C]
   (x y xy yx : object C)
   (px1 : arrow xy x)
   (py1 : arrow xy y)
@@ -89,7 +89,7 @@ Qed.
 #[export] Hint Resolve productCommutative : main.
 
 Theorem productAssociative
-  {C}
+  [C]
   (x y z xy yz xy_z x_yz : object C)
   (xy_to_x : arrow xy x)
   (xy_to_y : arrow xy y)
@@ -252,7 +252,7 @@ Qed.
 #[export] Hint Resolve productAssociative : main.
 
 Theorem productTerminal
-  {C}
+  [C]
   (x y xy : object C)
   (xy_to_x : arrow xy x)
   (xy_to_y : arrow xy y)

--- a/proofs/CategoryTheory/Terminal.v
+++ b/proofs/CategoryTheory/Terminal.v
@@ -14,10 +14,10 @@ Require Import Main.Tactics.
 
 #[local] Set Universe Polymorphism.
 
-Definition terminal {C} (x : object C) :=
+Definition terminal [C] (x : object C) :=
   forall y, exists f, forall (g : arrow y x), f = g.
 
-Theorem opInitialTerminal {C} x :
+Theorem opInitialTerminal [C] x :
   @initial C x <-> @terminal (oppositeCategory C) x.
 Proof.
   search.
@@ -25,7 +25,7 @@ Qed.
 
 #[export] Hint Resolve opInitialTerminal : main.
 
-Theorem opTerminalInitial {C} x :
+Theorem opTerminalInitial [C] x :
   @terminal C x <-> @initial (oppositeCategory C) x.
 Proof.
   search.

--- a/proofs/Tutorial/Lesson1_FunctionalProgramming.v
+++ b/proofs/Tutorial/Lesson1_FunctionalProgramming.v
@@ -168,7 +168,7 @@ Check id. (* `forall T : Set, T -> T` *)
   automatically whenever we use the function.
 *)
 
-Definition betterId {T : Set} (x : T) := x.
+Definition betterId [T : Set] (x : T) := x.
 
 Check betterId. (* `?T -> ?T where ?T : [|- Set]` *)
 
@@ -287,7 +287,7 @@ Check option. (* `Set -> Set` *)
   for the parameter argument.
 *)
 
-Definition mapOption {T U} f (o : option T) :=
+Definition mapOption [T U] f (o : option T) :=
   match o with
   | none _ => none U
   | some _ x => some U (f x)
@@ -311,9 +311,9 @@ Compute mapOption (fun n => true) (some nat 3). (* `some bool true` *)
   parameter implicit, but that would have affected `none` and `option` too.
 *)
 
-Arguments some {_} _.
+Arguments some [_] _.
 
-Check some. (* `?T -> option ?T where ?T : [|- Set]` *)
+Check some. (* `?T -> option ?T where ?T : {|- Set]` *)
 
 Compute mapOption (fun n => n + 1) (some 3). (* `some 4` *)
 

--- a/proofs/Tutorial/Lesson2_DependentTypes.v
+++ b/proofs/Tutorial/Lesson2_DependentTypes.v
@@ -152,7 +152,7 @@ Check someNat. (* `nat -> boolOrNat nat` *)
   could be an arbitrary expression.
 *)
 
-Definition pluck {T : Set} (x : boolOrNat T) :=
+Definition pluck [T : Set] (x : boolOrNat T) :=
   match x in boolOrNat U return U with
   | someBool b => b
   | someNat n => n
@@ -189,7 +189,7 @@ Inductive vector (T : Set) : nat -> Set :=
   determined automatically from the tail.
 *)
 
-Arguments nonempty {_ _} _ _.
+Arguments nonempty [_ _] _ _.
 
 (* Let's construct some `vector`s. *)
 
@@ -212,7 +212,7 @@ Compute zeroes 3. (* `nonempty 0 (nonempty 0 (nonempty 0 (empty nat)))` *)
 (* Here's a function which concatenates two `vector`s. *)
 
 Fixpoint concatenate
-           {T n1 n2}
+           [T n1 n2]
            (v1 : vector T n1)
            (v2 : vector T n2) :
            vector T (n1 + n2) :=
@@ -226,7 +226,7 @@ Fixpoint concatenate
   error to call this function on an empty `vector`.
 *)
 
-Definition head {T n} (v : vector T (S n)) : T :=
+Definition head [T n] (v : vector T (S n)) : T :=
   match v with
   | nonempty x _ => x
   end.

--- a/proofs/Tutorial/Lesson3_Logic.v
+++ b/proofs/Tutorial/Lesson3_Logic.v
@@ -72,7 +72,7 @@ Inductive False : Prop := .
 Inductive and (A B : Prop) : Prop :=
 | conj : A -> B -> and A B.
 
-Arguments conj {_ _} _ _.
+Arguments conj [_ _] _ _.
 
 (*
   The following specifies that the notation `A /\ B` will be used as shorthand
@@ -226,8 +226,8 @@ Inductive or (A B : Prop) : Prop :=
 | orIntroL : A -> or A B
 | orIntroR : B -> or A B.
 
-Arguments orIntroL {_ _} _.
-Arguments orIntroR {_ _} _.
+Arguments orIntroL [_ _] _.
+Arguments orIntroR [_ _] _.
 
 Notation "A \/ B" := (or A B) : type_scope.
 
@@ -280,7 +280,7 @@ Qed.
   proof is called *propositional equality*:
 *)
 
-Inductive eq {A} (x : A) : A -> Prop :=
+Inductive eq [A] (x : A) : A -> Prop :=
 | eq_refl : eq x x.
 
 Notation "x = y" := (eq x y) : type_scope.
@@ -407,10 +407,10 @@ Qed.
 
 (* *Existential quantification* can be defined as follows: *)
 
-Inductive ex {A : Type} (P : A -> Prop) : Prop :=
+Inductive ex [A : Type] (P : A -> Prop) : Prop :=
   ex_intro : forall x : A, P x -> ex P.
 
-Arguments ex_intro {_ _} _ _.
+Arguments ex_intro [_ _] _ _.
 
 (*
   The notation for existentials is somewhat tricky to specify. If you're

--- a/proofs/TypeTheory/Univalence.v
+++ b/proofs/TypeTheory/Univalence.v
@@ -6,7 +6,7 @@
 (*****************************************************)
 (*****************************************************)
 
-Definition equivalence {X Y : Set} (f : X -> Y) :=
+Definition equivalence [X Y : Set] (f : X -> Y) :=
   forall y,
   let fiber := { x | f x = y }
   in { x : fiber | forall z : fiber, x = z }.


### PR DESCRIPTION
Use `[` and `]` instead of `{` and `}` for implicit arguments.

**Status:** Ready

**Fixes:** N/A