### PR TITLE
Remove explicit `export` locality attributes in `Hint` commands now that the default is `export`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To write proofs, you'll want to use an IDE that supports interactive theorem pro
 
 You'll need the following:
 
-- [Coq](https://coq.inria.fr/) >= 8.17.1
+- [Coq](https://coq.inria.fr/) >= 8.18.0
   - Make sure to update your [`PATH`](https://en.wikipedia.org/wiki/PATH_\(variable\)) to include the location of the Coq binaries (`coqc`, `coqdep`, etc.).
 - [GNU Make](https://www.gnu.org/software/make/) >= 3.79.1
   - You also need these common Unix tools: `cp`, `find`, and `rm`. If you have `make`, you probably already have those other programs too.

--- a/proofs/admissibility_graph/admissibility_graph.v
+++ b/proofs/admissibility_graph/admissibility_graph.v
@@ -51,7 +51,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve transpose_involution : main.
+Hint Resolve transpose_involution : main.
 
 (*
   If there is a (possibly empty) chain of trust from one node to another, we
@@ -73,7 +73,7 @@ Proof.
     search.
 Qed.
 
-#[export] Hint Resolve transpose_trusting : main.
+Hint Resolve transpose_trusting : main.
 
 Theorem transpose_exporting Node (g : AdmissibilityGraph Node) :
   Exporting g = Trusting (transpose g).
@@ -82,7 +82,7 @@ Proof.
     search.
 Qed.
 
-#[export] Hint Resolve transpose_trusting : main.
+Hint Resolve transpose_trusting : main.
 
 (*
   Every node can depend on itself, the nodes it trusts, the nodes that export
@@ -98,7 +98,7 @@ Inductive Allowed [Node] (g : AdmissibilityGraph Node) (n : Node) : Node
 | egress : forall n1 n2, Trusts g n1 n -> Allowed g n1 n2 -> Allowed g n n2
 | ingress : forall n1 n2, Exports g n1 n2 -> Allowed g n n1 -> Allowed g n n2.
 
-#[export] Hint Constructors Allowed : main.
+Hint Constructors Allowed : main.
 
 (*
   The dependencies allowed by the transpose of a graph are the flipped versions
@@ -111,7 +111,7 @@ Proof.
   split; clean; induction H; esearch.
 Qed.
 
-#[export] Hint Resolve duality : main.
+Hint Resolve duality : main.
 
 (*
   If two admissibility graphs with the same nodes have corresponding edges
@@ -134,7 +134,7 @@ Proof.
   ).
 Qed.
 
-#[export] Hint Resolve reflection : main.
+Hint Resolve reflection : main.
 
 (* The following theorems generalize the egress and ingress axioms. *)
 
@@ -148,7 +148,7 @@ Proof.
   induction H; esearch.
 Qed.
 
-#[export] Hint Resolve egress_extension : main.
+Hint Resolve egress_extension : main.
 
 Theorem ingress_extension Node (g : AdmissibilityGraph Node) n1 n2 n3 :
   Exporting g n1 n2 ->
@@ -160,7 +160,7 @@ Proof.
   induction H; esearch.
 Qed.
 
-#[export] Hint Resolve ingress_extension : main.
+Hint Resolve ingress_extension : main.
 
 (*
   The following theorem gives an equivalent way to characterize which
@@ -195,7 +195,7 @@ Proof.
     apply ingress_extension with (n1 := x0); search.
 Qed.
 
-#[export] Hint Resolve admission : main.
+Hint Resolve admission : main.
 
 (*
   If a node trusts or exports another node, we say the former node is a
@@ -213,7 +213,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve transpose_parent_child : main.
+Hint Resolve transpose_parent_child : main.
 
 (*
   If there is a (possibly empty) chain of lineage from one node to another, we
@@ -241,7 +241,7 @@ Proof.
     + apply rt_trans with (y := y); search.
 Qed.
 
-#[export] Hint Resolve transpose_parent_child : main.
+Hint Resolve transpose_parent_child : main.
 
 (* The ancestor relation is a superset of the trusting relation. *)
 
@@ -253,7 +253,7 @@ Proof.
   apply rt_trans with (y := y); search.
 Qed.
 
-#[export] Hint Resolve trusting_ancestor : main.
+Hint Resolve trusting_ancestor : main.
 
 (* The ancestor relation is a superset of the exporting relation. *)
 
@@ -265,7 +265,7 @@ Proof.
   apply rt_trans with (y := y); search.
 Qed.
 
-#[export] Hint Resolve exporting_ancestor : main.
+Hint Resolve exporting_ancestor : main.
 
 (* It may be desirable to require the ancestor relation to be antisymmetric. *)
 
@@ -301,7 +301,7 @@ Proof.
     esearch.
 Qed.
 
-#[export] Hint Resolve transpose_module : main.
+Hint Resolve transpose_module : main.
 
 (*
   A node is *encapsulated* within a module if the module is an ancestor of the
@@ -332,7 +332,7 @@ Proof.
       search.
 Qed.
 
-#[export] Hint Resolve transpose_encapsulated : main.
+Hint Resolve transpose_encapsulated : main.
 
 Theorem transpose_sandboxed Node (g : AdmissibilityGraph Node) n1 n2 :
   Sandboxed g n1 n2 <-> Encapsulated (transpose g) n1 n2.
@@ -351,7 +351,7 @@ Proof.
       search.
 Qed.
 
-#[export] Hint Resolve transpose_sandboxed : main.
+Hint Resolve transpose_sandboxed : main.
 
 (*
   The nodes which can depend on a node encapsulated within a module are
@@ -405,7 +405,7 @@ Proof.
         apply rt_trans with (y := z0); search.
 Qed.
 
-#[export] Hint Resolve encapsulation : main.
+Hint Resolve encapsulation : main.
 
 (*
   The nodes which can be depended on by a node sandboxed within a module are
@@ -423,4 +423,4 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve sandboxing : main.
+Hint Resolve sandboxing : main.

--- a/proofs/category_theory/arrow.v
+++ b/proofs/category_theory/arrow.v
@@ -53,7 +53,7 @@ Proof.
   split; clean; exists x0; search.
 Qed.
 
-#[export] Hint Resolve op_isomorphism : main.
+Hint Resolve op_isomorphism : main.
 
 Theorem op_mono_epi [C x y] f :
   @Monomorphism C x y f <-> @Epimorphism (opposite_category C) y x f.
@@ -61,7 +61,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve op_mono_epi : main.
+Hint Resolve op_mono_epi : main.
 
 Theorem op_epi_mono [C x y] f :
   @Epimorphism C x y f <-> @Monomorphism (opposite_category C) y x f.
@@ -69,7 +69,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve op_epi_mono : main.
+Hint Resolve op_epi_mono : main.
 
 Theorem op_ret_sec [C x y] f :
   @Retraction C x y f <-> @Section (opposite_category C) y x f.
@@ -77,7 +77,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve op_ret_sec : main.
+Hint Resolve op_ret_sec : main.
 
 Theorem op_sec_ret [C x y] f :
   @Section C x y f <-> @Retraction (opposite_category C) y x f.
@@ -85,7 +85,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve op_sec_ret : main.
+Hint Resolve op_sec_ret : main.
 
 Theorem id_iso [C] x : Isomorphism (@id C x).
 Proof.
@@ -95,7 +95,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve id_iso : main.
+Hint Resolve id_iso : main.
 
 Theorem left_id_unique [C] (x : Object C):
   ArrowUnique (
@@ -109,7 +109,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve left_id_unique : main.
+Hint Resolve left_id_unique : main.
 
 Theorem right_id_unique [C] (x : Object C):
   ArrowUnique (
@@ -123,7 +123,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve right_id_unique : main.
+Hint Resolve right_id_unique : main.
 
 Theorem inverse_unique [C] [x y : Object C] (f : Arrow x y) :
   ArrowUnique (Inverse f).
@@ -137,7 +137,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve inverse_unique : main.
+Hint Resolve inverse_unique : main.
 
 Theorem inverse_involution [C] [x y : Object C] (f h : Arrow x y) g :
   Inverse f g -> Inverse g h -> f = h.
@@ -150,7 +150,7 @@ Proof.
     rewrite <- c_assoc. rewrite H. search.
 Qed.
 
-#[export] Hint Resolve inverse_involution : main.
+Hint Resolve inverse_involution : main.
 
 Theorem iso_implies_epi [C x y] f :
   @Isomorphism C x y f -> @Epimorphism C x y f.
@@ -167,7 +167,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve iso_implies_epi : main.
+Hint Resolve iso_implies_epi : main.
 
 Theorem iso_implies_mono [C x y] f :
   @Isomorphism C x y f -> @Monomorphism C x y f.
@@ -179,7 +179,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve iso_implies_mono : main.
+Hint Resolve iso_implies_mono : main.
 
 Theorem sec_implies_mono [C x y] f : @Section C x y f -> @Monomorphism C x y f.
 Proof.
@@ -194,7 +194,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve sec_implies_mono : main.
+Hint Resolve sec_implies_mono : main.
 
 Theorem ret_implies_epi [C x y] f :
   @Retraction C x y f -> @Epimorphism C x y f.
@@ -205,7 +205,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve ret_implies_epi : main.
+Hint Resolve ret_implies_epi : main.
 
 Theorem mono_ret_equiv_iso [C x y] f :
   @Monomorphism C x y f /\ @Retraction C x y f <-> @Isomorphism C x y f.
@@ -232,7 +232,7 @@ Proof.
     search.
 Qed.
 
-#[export] Hint Resolve mono_ret_equiv_iso : main.
+Hint Resolve mono_ret_equiv_iso : main.
 
 Theorem epi_sec_equiv_iso [C x y] f :
   @Epimorphism C x y f /\ @Section C x y f <-> @Isomorphism C x y f.
@@ -244,4 +244,4 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve epi_sec_equiv_iso : main.
+Hint Resolve epi_sec_equiv_iso : main.

--- a/proofs/category_theory/category.v
+++ b/proofs/category_theory/category.v
@@ -29,7 +29,7 @@ Arguments is_c_ident_left [_ _ _ _ _ _ _] _.
 Arguments is_c_ident_right [_ _ _ _ _ _ _] _.
 Arguments is_c_assoc [_ _ _ _ _ _ _ _ _] _ _ _.
 
-#[export] Hint Constructors IsCategory : main.
+Hint Constructors IsCategory : main.
 
 Record Category := {
   Object; Arrow; id; compose;
@@ -57,11 +57,11 @@ Definition c_assoc
   compose (compose f g) h = compose f (compose g h)
 := C.(category_laws).(is_c_assoc) f g h.
 
-#[export] Hint Resolve c_assoc : main.
-#[export] Hint Resolve c_ident_left : main.
-#[export] Hint Rewrite @c_ident_left : main.
-#[export] Hint Resolve c_ident_right : main.
-#[export] Hint Rewrite @c_ident_right : main.
+Hint Resolve c_assoc : main.
+Hint Resolve c_ident_left : main.
+Hint Rewrite @c_ident_left : main.
+Hint Resolve c_ident_right : main.
+Hint Rewrite @c_ident_right : main.
 
 Program Definition opposite_category C : Category := {|
   Object := Object C;
@@ -77,4 +77,4 @@ Proof.
   f_equal; apply proof_irrelevance.
 Qed.
 
-#[export] Hint Resolve opposite_involution : main.
+Hint Resolve opposite_involution : main.

--- a/proofs/category_theory/coproduct.v
+++ b/proofs/category_theory/coproduct.v
@@ -35,7 +35,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve op_coproduct_product : main.
+Hint Resolve op_coproduct_product : main.
 
 Theorem op_product_coproduct C x y xy px py :
   @product C x y xy px py <-> @coproduct (opposite_category C) x y xy px py.
@@ -43,7 +43,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve op_product_coproduct : main.
+Hint Resolve op_product_coproduct : main.
 
 Theorem coproduct_unique C (x y : Object C) :
   UniqueUpToIsomorphism (fun xy => exists ix iy, coproduct x y xy ix iy).
@@ -56,7 +56,7 @@ Proof.
   esearch.
 Qed.
 
-#[export] Hint Resolve coproduct_unique : main.
+Hint Resolve coproduct_unique : main.
 
 Theorem coproduct_commutator
   [C]
@@ -88,7 +88,7 @@ Proof.
   apply product_commutative.
 Qed.
 
-#[export] Hint Resolve coproduct_commutative : main.
+Hint Resolve coproduct_commutative : main.
 
 Theorem coproduct_associative
   [C]
@@ -112,7 +112,7 @@ Proof.
   apply product_associative.
 Qed.
 
-#[export] Hint Resolve coproduct_associative : main.
+Hint Resolve coproduct_associative : main.
 
 Theorem coproduct_initial
   [C]
@@ -127,4 +127,4 @@ Proof.
   apply product_terminal.
 Qed.
 
-#[export] Hint Resolve coproduct_initial : main.
+Hint Resolve coproduct_initial : main.

--- a/proofs/category_theory/equivalence.v
+++ b/proofs/category_theory/equivalence.v
@@ -59,4 +59,4 @@ Proof.
     search.
 Qed.
 
-#[export] Hint Resolve equivalent_refl : main.
+Hint Resolve equivalent_refl : main.

--- a/proofs/category_theory/functor.v
+++ b/proofs/category_theory/functor.v
@@ -28,10 +28,10 @@ Arguments f_map [_ _] _ [_ _] _.
 Arguments f_ident [_ _] _ _.
 Arguments f_comp [_ _] _ [_ _ _] _ _.
 
-#[export] Hint Resolve f_ident : main.
-#[export] Hint Rewrite @f_ident : main.
-#[export] Hint Resolve f_comp : main.
-#[export] Hint Rewrite @f_comp : main.
+Hint Resolve f_ident : main.
+Hint Rewrite @f_ident : main.
+Hint Resolve f_comp : main.
+Hint Rewrite @f_comp : main.
 
 Definition endofunctor C := Functor C C.
 
@@ -55,7 +55,7 @@ Proof.
   f_equal; apply proof_irrelevance.
 Qed.
 
-#[export] Hint Resolve comp_functor_ident_left : main.
+Hint Resolve comp_functor_ident_left : main.
 
 Theorem comp_functor_ident_right [C D] (F : Functor C D) :
   comp_functor F (id_functor D) = F.
@@ -65,7 +65,7 @@ Proof.
   f_equal; apply proof_irrelevance.
 Qed.
 
-#[export] Hint Resolve comp_functor_ident_right : main.
+Hint Resolve comp_functor_ident_right : main.
 
 Theorem comp_functor_assoc
   [B C D E]
@@ -78,4 +78,4 @@ Proof.
   f_equal; apply proof_irrelevance.
 Qed.
 
-#[export] Hint Resolve comp_functor_assoc : main.
+Hint Resolve comp_functor_assoc : main.

--- a/proofs/category_theory/initial.v
+++ b/proofs/category_theory/initial.v
@@ -31,4 +31,4 @@ Proof.
   split; search.
 Qed.
 
-#[export] Hint Resolve initial_unique : main.
+Hint Resolve initial_unique : main.

--- a/proofs/category_theory/monad.v
+++ b/proofs/category_theory/monad.v
@@ -35,11 +35,11 @@ Arguments m_assoc [_ _ _ _] _.
 Arguments m_ident1 [_ _ _ _] _.
 Arguments m_ident2 [_ _ _ _] _.
 
-#[export] Hint Resolve m_assoc : main.
-#[export] Hint Resolve m_ident1 : main.
-#[export] Hint Rewrite @m_ident1 : main.
-#[export] Hint Resolve m_ident2 : main.
-#[export] Hint Rewrite @m_ident2 : main.
+Hint Resolve m_assoc : main.
+Hint Resolve m_ident1 : main.
+Hint Rewrite @m_ident1 : main.
+Hint Resolve m_ident2 : main.
+Hint Rewrite @m_ident2 : main.
 
 Theorem eq_monad
   [C]
@@ -54,4 +54,4 @@ Proof.
   f_equal; apply proof_irrelevance.
 Qed.
 
-#[export] Hint Resolve eq_monad : main.
+Hint Resolve eq_monad : main.

--- a/proofs/category_theory/natural_transformation.v
+++ b/proofs/category_theory/natural_transformation.v
@@ -27,8 +27,8 @@ Record NaturalTransformation [C D] (F G : Functor C D) := {
 Arguments eta [_ _ _ _] _ _.
 Arguments naturality [_ _ _ _] _ [_ _] _.
 
-#[export] Hint Resolve naturality : main.
-#[export] Hint Rewrite @naturality : main.
+Hint Resolve naturality : main.
+Hint Rewrite @naturality : main.
 
 Theorem eq_natural_transformation
   [C D]
@@ -54,7 +54,7 @@ Proof.
     search.
 Qed.
 
-#[export] Hint Resolve eq_natural_transformation : main.
+Hint Resolve eq_natural_transformation : main.
 
 Program Definition left_whisker
   [C D E]
@@ -134,7 +134,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve hor_comp_natural_transformation_alt : main.
+Hint Resolve hor_comp_natural_transformation_alt : main.
 
 Definition natural_isomorphism
   [C D] [F G : Functor C D]

--- a/proofs/category_theory/object.v
+++ b/proofs/category_theory/object.v
@@ -27,7 +27,7 @@ Proof.
   esearch.
 Qed.
 
-#[export] Hint Resolve isomorphic_refl : main.
+Hint Resolve isomorphic_refl : main.
 
 Theorem isomorphic_trans [C] (x y z : Object C) :
   Isomorphic x y -> Isomorphic y z -> Isomorphic x z.
@@ -77,4 +77,4 @@ Proof.
   ]; search.
 Qed.
 
-#[export] Hint Resolve op_isomorphic : main.
+Hint Resolve op_isomorphic : main.

--- a/proofs/category_theory/product.v
+++ b/proofs/category_theory/product.v
@@ -47,7 +47,7 @@ Proof.
     split; rewrite c_assoc; search.
 Qed.
 
-#[export] Hint Resolve product_unique : main.
+Hint Resolve product_unique : main.
 
 Theorem product_commutator
   [C]
@@ -86,7 +86,7 @@ Proof.
   apply H1; esearch.
 Qed.
 
-#[export] Hint Resolve product_commutative : main.
+Hint Resolve product_commutative : main.
 
 Theorem product_associative
   [C]
@@ -249,7 +249,7 @@ Proof.
       search.
 Qed.
 
-#[export] Hint Resolve product_associative : main.
+Hint Resolve product_associative : main.
 
 Theorem product_terminal
   [C]
@@ -281,4 +281,4 @@ Proof.
     esearch.
 Qed.
 
-#[export] Hint Resolve product_terminal : main.
+Hint Resolve product_terminal : main.

--- a/proofs/category_theory/terminal.v
+++ b/proofs/category_theory/terminal.v
@@ -23,7 +23,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve op_initial_terminal : main.
+Hint Resolve op_initial_terminal : main.
 
 Theorem op_terminal_initial [C] x :
   @terminal C x <-> @initial (opposite_category C) x.
@@ -31,7 +31,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve op_terminal_initial : main.
+Hint Resolve op_terminal_initial : main.
 
 Theorem terminal_unique C : UniqueUpToIsomorphism (@terminal C).
 Proof.
@@ -42,4 +42,4 @@ Proof.
   apply initial_unique; search.
 Qed.
 
-#[export] Hint Resolve terminal_unique : main.
+Hint Resolve terminal_unique : main.

--- a/proofs/crdt/operation_crdt.v
+++ b/proofs/crdt/operation_crdt.v
@@ -41,7 +41,7 @@ Arguments interpret [_ _] _ _.
 Arguments query [_ _] _.
 Arguments Precondition [_ _] _ _.
 
-#[export] Hint Constructors CrdtData : main.
+Hint Constructors CrdtData : main.
 
 (*
   The history of a node is a list of operations. `o :: h` is understood as a
@@ -70,7 +70,7 @@ Inductive HistoryValid [A Q] (crdt_data : CrdtData A Q)
   crdt_data.(Precondition) (run crdt_data h) o ->
   HistoryValid _ (o :: h).
 
-#[export] Hint Constructors HistoryValid : main.
+Hint Constructors HistoryValid : main.
 
 (*
   A history is *consistent* with a partial order when every operation in the
@@ -84,7 +84,7 @@ Inductive HistoryConsistent [T] (R : T -> T -> Prop) : list T -> Prop :=
   (forall o2, In o2 h -> ~ R o1 o2) ->
   HistoryConsistent _ (o1 :: h).
 
-#[export] Hint Constructors HistoryConsistent : main.
+Hint Constructors HistoryConsistent : main.
 
 (*
   A partial order is *satisfactory* for a set of operations if every history
@@ -123,7 +123,7 @@ Record Crdt [A Q] (crdt_data : CrdtData A Q) := {
       crdt_data.(interpret) o2 (crdt_data.(interpret) o1 s);
 }.
 
-#[export] Hint Constructors Crdt : main.
+Hint Constructors Crdt : main.
 
 (*
   We're now ready to state and prove the strong convergence theorem: any two
@@ -272,7 +272,7 @@ Proof.
               ** destruct H8; search.
 Qed.
 
-#[export] Hint Resolve strong_convergence : main.
+Hint Resolve strong_convergence : main.
 
 (* A simple operation-based CRDT: a counter *)
 

--- a/proofs/crdt/state_crdt.v
+++ b/proofs/crdt/state_crdt.v
@@ -23,7 +23,7 @@ Record AlgebraicSemilattice [T] (initial : T) (merge : T -> T -> T) := {
   identity x : merge initial x = x;
 }.
 
-#[export] Hint Constructors AlgebraicSemilattice : main.
+Hint Constructors AlgebraicSemilattice : main.
 
 (*
   There other way to define a semilattice is a bit more complicated than the
@@ -40,7 +40,7 @@ Record PartialOrder [T] (R : T -> T -> Prop) := {
   antisymmetry x y : R x y -> R y x -> x = y;
 }.
 
-#[export] Hint Constructors PartialOrder : main.
+Hint Constructors PartialOrder : main.
 
 (* An *upper bound* of two elements is at least as large as those elements. *)
 
@@ -72,7 +72,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve partial_order_determined_by_least_upper_bounds : main.
+Hint Resolve partial_order_determined_by_least_upper_bounds : main.
 
 (*
   A bounded *join-semilattice* is a partial order in which any finite subset of
@@ -117,7 +117,7 @@ Proof.
         -- specialize (H1 x (merge y z)). search.
 Qed.
 
-#[export] Hint Resolve semilattice_correspondence : main.
+Hint Resolve semilattice_correspondence : main.
 
 (*
   A *state-based CRDT* is a bounded semilattice of states (as defined above)
@@ -140,7 +140,7 @@ Arguments merge [_ _] _ _.
 Arguments update [_ _] _ _.
 Arguments query [_ _] _.
 
-#[export] Hint Constructors Crdt : main.
+Hint Constructors Crdt : main.
 
 (*
   The *history* of a node is the graph of operations that led to the current
@@ -156,7 +156,7 @@ Inductive History [A Q] (crdt : Crdt A Q) :=
 Arguments up_update [_ _ _] _ _ _.
 Arguments op_merge [_ _ _] _ _.
 
-#[export] Hint Constructors History : main.
+Hint Constructors History : main.
 
 (*
   Any updates with the same ID should be identical. To formalize that, we
@@ -179,7 +179,7 @@ Inductive HistoryConsistent
   HistoryConsistent _ h2 ->
   HistoryConsistent _ (op_merge h1 h2).
 
-#[export] Hint Constructors HistoryConsistent : main.
+Hint Constructors HistoryConsistent : main.
 
 (*
   The following relation indicates when a node's history contains an update
@@ -197,7 +197,7 @@ Inductive InHistory [A Q] [crdt : Crdt A Q] n1
 | in_merge_right :
   forall h1 h2, InHistory _ h2 -> InHistory _ (op_merge h1 h2).
 
-#[export] Hint Constructors InHistory : main.
+Hint Constructors InHistory : main.
 
 (* This function replays a node's history to compute its current state. *)
 
@@ -246,7 +246,7 @@ Proof.
     search.
 Qed.
 
-#[export] Hint Resolve run_upper_bound : main.
+Hint Resolve run_upper_bound : main.
 
 (*
   We're now ready to state and prove the strong convergence theorem: any two
@@ -293,7 +293,7 @@ Proof.
         search.
 Qed.
 
-#[export] Hint Resolve strong_convergence : main.
+Hint Resolve strong_convergence : main.
 
 (* A simple state-based CRDT: a Boolean event flag *)
 

--- a/proofs/kleene/kleene_data.v
+++ b/proofs/kleene/kleene_data.v
@@ -20,10 +20,10 @@ Module Type KleeneData.
   Axiom transitivity : forall x y z, Leq x y -> Leq y z -> Leq x z.
   Axiom antisymmetry : forall x y, Leq x y -> Leq y x -> x = y.
 
-  #[export] Hint Resolve reflexivity : main.
-  #[export] Hint Resolve transitivity : main.
-  #[export] Hint Resolve antisymmetry: main.
-  #[export] Hint Rewrite antisymmetry: main.
+  Hint Resolve reflexivity : main.
+  Hint Resolve transitivity : main.
+  Hint Resolve antisymmetry: main.
+  Hint Rewrite antisymmetry: main.
 
   (*
     A supremum of a subset of `T` is a least element of `T` which is greater
@@ -35,7 +35,7 @@ Module Type KleeneData.
     (forall x2, P x2 -> Leq x2 x1) /\
     forall x3, (forall x2, P x2 -> Leq x2 x3) -> Leq x1 x3.
 
-  #[export] Hint Unfold Supremum : main.
+  Hint Unfold Supremum : main.
 
   (*
     A directed subset of `T` is a non-empty subset of `T` such that any two
@@ -46,7 +46,7 @@ Module Type KleeneData.
     (exists x1, P x1) /\
     forall x1 x2, P x1 -> P x2 -> exists x3, Leq x1 x3 /\ Leq x2 x3 /\ P x3.
 
-  #[export] Hint Unfold Directed : main.
+  Hint Unfold Directed : main.
 
   (*
     Assumption: Let the partial order be directed-complete. That means every
@@ -58,7 +58,7 @@ Module Type KleeneData.
     Directed P ->
     exists x, Supremum P x.
 
-  #[export] Hint Resolve directed_complete : main.
+  Hint Resolve directed_complete : main.
 
   (*
     Assumption: Let `T` have a least element called bottom. This makes our
@@ -69,5 +69,5 @@ Module Type KleeneData.
 
   Axiom bottom_least : forall x, Leq bottom x.
 
-  #[export] Hint Resolve bottom_least : main.
+  Hint Resolve bottom_least : main.
 End KleeneData.

--- a/proofs/kleene/kleene_theorems.v
+++ b/proofs/kleene/kleene_theorems.v
@@ -26,7 +26,7 @@ Module KleeneTheorems (Kleene : KleeneData).
 
   Definition Monotone f := forall x1 x2, Leq x1 x2 -> Leq (f x1) (f x2).
 
-  #[export] Hint Unfold Monotone : main.
+  Hint Unfold Monotone : main.
 
   (*
     A function is Scott-continuous if it preserves suprema of directed subsets.
@@ -41,7 +41,7 @@ Module KleeneTheorems (Kleene : KleeneData).
     Supremum P x1 ->
     Supremum (fun x2 => exists x3, P x3 /\ x2 = f x3) (f x1).
 
-  #[export] Hint Unfold Continuous : main.
+  Hint Unfold Continuous : main.
 
   (* This function performs iterated application of a function to `bottom`. *)
 
@@ -81,7 +81,7 @@ Module KleeneTheorems (Kleene : KleeneData).
     unfold Supremum. search.
   Qed.
 
-  #[export] Hint Resolve supremum_uniqueness : main.
+  Hint Resolve supremum_uniqueness : main.
 
   (* Scott-continuity implies monotonicity. *)
 
@@ -93,7 +93,7 @@ Module KleeneTheorems (Kleene : KleeneData).
     - unfold Supremum in H. feed H; esearch.
   Qed.
 
-  #[export] Hint Resolve continuous_implis_monotone : main.
+  Hint Resolve continuous_implis_monotone : main.
 
   (*
     Iterated applications of a monotone function `f` to bottom form an
@@ -111,7 +111,7 @@ Module KleeneTheorems (Kleene : KleeneData).
     - left. clean. induction n; search.
   Qed.
 
-  #[export] Hint Resolve omega_chain : main.
+  Hint Resolve omega_chain : main.
 
   (* The ascending kleene chain of `f` is directed. *)
 
@@ -130,7 +130,7 @@ Module KleeneTheorems (Kleene : KleeneData).
       + exists (approx f x). esearch.
   Qed.
 
-  #[export] Hint Resolve kleene_chain_directed : main.
+  Hint Resolve kleene_chain_directed : main.
 
   (**********************************)
   (* The kleene fixed-point theorem *)
@@ -185,5 +185,5 @@ Module KleeneTheorems (Kleene : KleeneData).
         * unfold Supremum in H1. search.
   Qed.
 
-  #[export] Hint Resolve kleene : main.
+  Hint Resolve kleene : main.
 End KleeneTheorems.

--- a/proofs/kleene/trivial_kleene_data.v
+++ b/proofs/kleene/trivial_kleene_data.v
@@ -13,11 +13,11 @@ Require Import main.tactics.
 Module TrivialKleeneData <: KleeneData.
   Definition T := unit.
 
-  #[export] Hint Unfold T : main.
+  Hint Unfold T : main.
 
   Definition Leq (x y : T) := True.
 
-  #[export] Hint Unfold Leq : main.
+  Hint Unfold Leq : main.
 
   Theorem reflexivity : forall x, Leq x x.
   Proof.
@@ -45,14 +45,14 @@ Module TrivialKleeneData <: KleeneData.
     (forall x2, P x2 -> Leq x2 x1) /\
     forall x3, (forall x2, P x2 -> Leq x2 x3) -> Leq x1 x3.
 
-  #[export] Hint Unfold Supremum : main.
+  Hint Unfold Supremum : main.
 
   (* Coq requires that we copy this verbatim from `ContextGraph`. *)
   Definition Directed P :=
     (exists x1, P x1) /\
     forall x1 x2, P x1 -> P x2 -> exists x3, Leq x1 x3 /\ Leq x2 x3 /\ P x3.
 
-  #[export] Hint Unfold Directed : main.
+  Hint Unfold Directed : main.
 
   Theorem directed_complete :
     forall P,
@@ -66,7 +66,7 @@ Module TrivialKleeneData <: KleeneData.
 
   Definition bottom := tt.
 
-  #[export] Hint Unfold bottom : main.
+  Hint Unfold bottom : main.
 
   Theorem bottom_least : forall x, Leq bottom x.
   Proof.

--- a/proofs/stlc/free_var.v
+++ b/proofs/stlc/free_var.v
@@ -39,4 +39,4 @@ Inductive Free_var : Term -> Name -> Prop :=
   Free_var e2 x ->
   Free_var (e_app e1 e2) x.
 
-#[export] Hint Constructors Free_var : main.
+Hint Constructors Free_var : main.

--- a/proofs/stlc/name.v
+++ b/proofs/stlc/name.v
@@ -26,7 +26,7 @@ Module Name : NameSig.
     induction x1; search.
   Qed.
 
-  #[export] Hint Resolve name_eq : main.
+  Hint Resolve name_eq : main.
 
 End Name.
 

--- a/proofs/stlc/preservation.v
+++ b/proofs/stlc/preservation.v
@@ -22,7 +22,7 @@ Proof.
   clean. induction H; invert H0; esearch.
 Qed.
 
-#[export] Hint Resolve typing_judgment_closed : main.
+Hint Resolve typing_judgment_closed : main.
 
 Theorem context_invariance :
   forall c1 c2 e t,
@@ -36,7 +36,7 @@ Proof.
   - eapply ht_app; search.
 Qed.
 
-#[export] Hint Resolve context_invariance : main.
+Hint Resolve context_invariance : main.
 
 Theorem substitution_preserves_typing :
   forall c x e1 e2 t1 t2,
@@ -56,7 +56,7 @@ Proof.
       search.
 Qed.
 
-#[export] Hint Resolve substitution_preserves_typing : main.
+Hint Resolve substitution_preserves_typing : main.
 
 Theorem preservation :
   forall e1 e2 t,
@@ -71,4 +71,4 @@ Proof.
     invert H; search.
 Qed.
 
-#[export] Hint Resolve preservation : main.
+Hint Resolve preservation : main.

--- a/proofs/stlc/progress.v
+++ b/proofs/stlc/progress.v
@@ -20,4 +20,4 @@ Proof.
   - destruct IHHasType1; destruct IHHasType2; esearch. invert H; esearch.
 Qed.
 
-#[export] Hint Resolve progress : main.
+Hint Resolve progress : main.

--- a/proofs/stlc/semantics.v
+++ b/proofs/stlc/semantics.v
@@ -14,7 +14,7 @@ Inductive Value : Term -> Prop :=
 | v_false : Value e_false
 | v_abs : forall e x t, Value (e_abs x t e).
 
-#[export] Hint Constructors Value : main.
+Hint Constructors Value : main.
 
 Inductive Step : Term -> Term -> Prop :=
 | s_if1 :
@@ -41,7 +41,7 @@ Inductive Step : Term -> Term -> Prop :=
   Step e2 e3 ->
   Step (e_app e1 e2) (e_app e1 e3).
 
-#[export] Hint Constructors Step : main.
+Hint Constructors Step : main.
 
 Inductive StepStar : Term -> Term -> Prop :=
 | ss_refl :
@@ -53,4 +53,4 @@ Inductive StepStar : Term -> Term -> Prop :=
   StepStar e2 e3 ->
   StepStar e1 e3.
 
-#[export] Hint Constructors StepStar : main.
+Hint Constructors StepStar : main.

--- a/proofs/stlc/soundness.v
+++ b/proofs/stlc/soundness.v
@@ -21,4 +21,4 @@ Proof.
   clean. induction H0; esearch.
 Qed.
 
-#[export] Hint Resolve soundness : main.
+Hint Resolve soundness : main.

--- a/proofs/stlc/typing.v
+++ b/proofs/stlc/typing.v
@@ -46,4 +46,4 @@ Inductive HasType : Context -> Term -> Ty -> Prop :=
   HasType c e2 t2 ->
   HasType c (e_app e1 e2) t1.
 
-#[export] Hint Constructors HasType : main.
+Hint Constructors HasType : main.

--- a/proofs/system_f/context.v
+++ b/proofs/system_f/context.v
@@ -85,7 +85,7 @@ Inductive CWellFormed : Context -> Prop :=
   CWellFormed c ->
   CWellFormed (c_t_extend c x).
 
-#[export] Hint Constructors CWellFormed : main.
+Hint Constructors CWellFormed : main.
 
 (*****************************)
 (* Concatenation of contexts *)
@@ -120,8 +120,8 @@ Proof.
   clean. split; induction c; esearch. clean. destruct H; esearch.
 Qed.
 
-#[export] Hint Resolve -> e_domain_lookup : main.
-#[export] Hint Resolve <- e_domain_lookup : main.
+Hint Resolve -> e_domain_lookup : main.
+Hint Resolve <- e_domain_lookup : main.
 
 Theorem t_domain_lookup :
   forall c x,
@@ -130,8 +130,8 @@ Proof.
   clean. induction c; search.
 Qed.
 
-#[export] Hint Resolve -> t_domain_lookup : main.
-#[export] Hint Resolve <- t_domain_lookup : main.
+Hint Resolve -> t_domain_lookup : main.
+Hint Resolve <- t_domain_lookup : main.
 
 (************************************)
 (* Facts about type well-formedness *)
@@ -146,7 +146,7 @@ Proof.
   clean. apply t_domain_lookup. invert H. search.
 Qed.
 
-#[export] Hint Resolve t_well_formed_closed : main.
+Hint Resolve t_well_formed_closed : main.
 
 Theorem t_lookup_well_formed :
   forall c x t,
@@ -158,7 +158,7 @@ Proof.
   destruct (name_eq x x0); search. clean. invert H0. search.
 Qed.
 
-#[export] Hint Resolve t_lookup_well_formed : main.
+Hint Resolve t_lookup_well_formed : main.
 
 (****************************)
 (* Facts about substitution *)
@@ -171,7 +171,7 @@ Proof.
   induction c; search.
 Qed.
 
-#[export] Hint Resolve c_sub_e_domain : main.
+Hint Resolve c_sub_e_domain : main.
 
 Theorem c_sub_t_domain :
   forall c x t,
@@ -180,7 +180,7 @@ Proof.
   induction c; search.
 Qed.
 
-#[export] Hint Resolve c_sub_t_domain : main.
+Hint Resolve c_sub_t_domain : main.
 
 (*****************************************)
 (* Facts about concatenation of contexts *)
@@ -191,7 +191,7 @@ Proof.
   induction c; search.
 Qed.
 
-#[export] Hint Resolve c_concat_empty : main.
+Hint Resolve c_concat_empty : main.
 
 Theorem c_concat_assoc :
   forall c1 c2 c3,
@@ -200,7 +200,7 @@ Proof.
   induction c2; induction c3; search.
 Qed.
 
-#[export] Hint Resolve c_concat_assoc : main.
+Hint Resolve c_concat_assoc : main.
 
 (*****************************************)
 (* Facts about concatenation and domains *)
@@ -213,7 +213,7 @@ Proof.
   induction c2; search.
 Qed.
 
-#[export] Hint Resolve e_domain_concat : main.
+Hint Resolve e_domain_concat : main.
 
 Theorem t_domain_concat :
   forall c1 c2,
@@ -222,7 +222,7 @@ Proof.
   induction c2; search.
 Qed.
 
-#[export] Hint Resolve t_domain_concat : main.
+Hint Resolve t_domain_concat : main.
 
 (****************************************)
 (* Facts about concatenation and lookup *)
@@ -236,7 +236,7 @@ Proof.
   induction c2; search.
 Qed.
 
-#[export] Hint Resolve c_concat_e_lookup : main.
+Hint Resolve c_concat_e_lookup : main.
 
 Theorem c_concat_t_lookup :
   forall c1 c2 x,
@@ -246,7 +246,7 @@ Proof.
   induction c2; search.
 Qed.
 
-#[export] Hint Resolve c_concat_t_lookup : main.
+Hint Resolve c_concat_t_lookup : main.
 
 Theorem c_e_lookup_concat_right :
   forall c1 c2 t x,
@@ -256,7 +256,7 @@ Proof.
   induction c2; search.
 Qed.
 
-#[export] Hint Resolve c_e_lookup_concat_right : main.
+Hint Resolve c_e_lookup_concat_right : main.
 
 Theorem c_e_lookup_concat_left :
   forall c1 c2 t x,
@@ -267,7 +267,7 @@ Proof.
   induction c2; search.
 Qed.
 
-#[export] Hint Resolve c_e_lookup_concat_left : main.
+Hint Resolve c_e_lookup_concat_left : main.
 
 Theorem c_t_lookup_concat_right :
   forall c1 c2 x,
@@ -277,7 +277,7 @@ Proof.
   induction c2; search.
 Qed.
 
-#[export] Hint Resolve c_t_lookup_concat_right : main.
+Hint Resolve c_t_lookup_concat_right : main.
 
 Theorem c_t_lookup_concat_left :
   forall c1 c2 x,
@@ -287,7 +287,7 @@ Proof.
   induction c2; search.
 Qed.
 
-#[export] Hint Resolve c_t_lookup_concat_left : main.
+Hint Resolve c_t_lookup_concat_left : main.
 
 Theorem c_e_lookup_none :
   forall c1 c2 t x,
@@ -302,7 +302,7 @@ Proof.
   unfold not in H4. search.
 Qed.
 
-#[export] Hint Resolve c_e_lookup_none : main.
+Hint Resolve c_e_lookup_none : main.
 
 Theorem c_t_lookup_none :
   forall c1 c2 x,
@@ -317,7 +317,7 @@ Proof.
   unfold not in H3. search.
 Qed.
 
-#[export] Hint Resolve c_t_lookup_none : main.
+Hint Resolve c_t_lookup_none : main.
 
 (***************************************)
 (* Facts about context well-formedness *)
@@ -338,7 +338,7 @@ Proof.
   - rewrite t_domain_concat in *. search.
 Qed.
 
-#[export] Hint Resolve c_well_formed_e_skip : main.
+Hint Resolve c_well_formed_e_skip : main.
 
 Theorem c_well_formed_t_skip :
   forall c1 c2 t x,
@@ -376,4 +376,4 @@ Proof.
     rewrite c_sub_t_domain in H1. search.
 Qed.
 
-#[export] Hint Resolve c_well_formed_t_skip : main.
+Hint Resolve c_well_formed_t_skip : main.

--- a/proofs/system_f/local_closure.v
+++ b/proofs/system_f/local_closure.v
@@ -27,7 +27,7 @@ Inductive TLocallyClosed : Ty -> nat -> Prop :=
   TLocallyClosed t (S n) ->
   TLocallyClosed (t_for_all t) n.
 
-#[export] Hint Constructors TLocallyClosed : main.
+Hint Constructors TLocallyClosed : main.
 
 Inductive ELocallyClosed : Term -> nat -> nat -> Prop :=
 | elc_free_var :
@@ -57,7 +57,7 @@ Inductive ELocallyClosed : Term -> nat -> nat -> Prop :=
   TLocallyClosed t nt ->
   ELocallyClosed (e_t_app e t) ne nt.
 
-#[export] Hint Constructors ELocallyClosed : main.
+Hint Constructors ELocallyClosed : main.
 
 (*************************************************)
 (* Local closure is monotonic with the level(s). *)

--- a/proofs/system_f/name.v
+++ b/proofs/system_f/name.v
@@ -29,7 +29,7 @@ Module Name : NameSig.
     induction x1; search.
   Qed.
 
-  #[export] Hint Resolve name_eq : main.
+  Hint Resolve name_eq : main.
 
   Theorem name_fresh : forall l : list nat, exists x, ~ In x l.
   Proof.
@@ -41,7 +41,7 @@ Module Name : NameSig.
     - specialize (H0 (S (fold_right Nat.max 0 l))). search.
   Qed.
 
-  #[export] Hint Resolve name_fresh : main.
+  Hint Resolve name_fresh : main.
 
 End Name.
 
@@ -59,4 +59,4 @@ Proof.
   clean. induction l; search.
 Qed.
 
-#[export] Hint Resolve name_in_remove : main.
+Hint Resolve name_in_remove : main.

--- a/proofs/system_f/opening.v
+++ b/proofs/system_f/opening.v
@@ -55,7 +55,7 @@ Proof.
   clean. induction H; search.
 Qed.
 
-#[export] Hint Resolve ttt_open_locally_closed : main.
+Hint Resolve ttt_open_locally_closed : main.
 
 Theorem eee_open_locally_closed :
   forall e1 e2 ie it,
@@ -65,7 +65,7 @@ Proof.
   clean. induction H; search.
 Qed.
 
-#[export] Hint Resolve eee_open_locally_closed : main.
+Hint Resolve eee_open_locally_closed : main.
 
 Theorem eet_open_locally_closed :
   forall e ie it t,
@@ -75,7 +75,7 @@ Proof.
   clean. induction H; search.
 Qed.
 
-#[export] Hint Resolve eet_open_locally_closed : main.
+Hint Resolve eet_open_locally_closed : main.
 
 (***************************************************************************)
 (* If the opening of a term/type is locally closed at some level, then the *)
@@ -95,7 +95,7 @@ Proof.
   - invert H. search.
 Qed.
 
-#[export] Hint Resolve t_t_locally_closed_open : main.
+Hint Resolve t_t_locally_closed_open : main.
 
 Theorem e_e_locally_closed_open :
   forall e1 e2 ie it,
@@ -112,7 +112,7 @@ Proof.
   - invert H. search.
 Qed.
 
-#[export] Hint Resolve e_e_locally_closed_open : main.
+Hint Resolve e_e_locally_closed_open : main.
 
 Theorem e_t_locally_closed_open :
   forall e ie it t,
@@ -128,7 +128,7 @@ Proof.
   - invert H. esearch.
 Qed.
 
-#[export] Hint Resolve e_t_locally_closed_open : main.
+Hint Resolve e_t_locally_closed_open : main.
 
 (********************************)
 (* Free variables of an opening *)
@@ -146,7 +146,7 @@ Proof.
   - induction t1; search. unfold incl. search.
 Qed.
 
-#[export] Hint Resolve ttt_free_open : main.
+Hint Resolve ttt_free_open : main.
 
 Theorem eeee_free_open :
   forall e1 e2 i,
@@ -160,7 +160,7 @@ Proof.
   - induction e1; search. unfold incl. search.
 Qed.
 
-#[export] Hint Resolve eeee_free_open : main.
+Hint Resolve eeee_free_open : main.
 
 Theorem eeet_free_open :
   forall e i t,
@@ -170,7 +170,7 @@ Proof.
   clean. split; outro i; induction e; search.
 Qed.
 
-#[export] Hint Resolve eeet_free_open : main.
+Hint Resolve eeet_free_open : main.
 
 Theorem etee_free_open :
   forall e1 e2 i,
@@ -191,7 +191,7 @@ Proof.
   - induction e1; search. unfold incl. search.
 Qed.
 
-#[export] Hint Resolve etee_free_open : main.
+Hint Resolve etee_free_open : main.
 
 Theorem etet_free_open :
   forall e i t,
@@ -214,7 +214,7 @@ Proof.
       apply ttt_free_open.
 Qed.
 
-#[export] Hint Resolve etet_free_open : main.
+Hint Resolve etet_free_open : main.
 
 (********************************************)
 (* Opening binders preserves local closure. *)
@@ -237,7 +237,7 @@ Proof.
     search.
 Qed.
 
-#[export] Hint Resolve locally_closed_open_for_all : main.
+Hint Resolve locally_closed_open_for_all : main.
 
 Theorem locally_closed_open_abs :
   forall e1 e2 ie it t,
@@ -258,7 +258,7 @@ Proof.
     apply e_local_closure_monotonic with (ie1 := ie) (it1 := nt); search.
 Qed.
 
-#[export] Hint Resolve locally_closed_open_abs : main.
+Hint Resolve locally_closed_open_abs : main.
 
 Theorem locally_closed_open_t_abs :
   forall e ie it t,
@@ -282,4 +282,4 @@ Proof.
     apply t_local_closure_monotonic with (i1 := nt); search.
 Qed.
 
-#[export] Hint Resolve locally_closed_open_t_abs : main.
+Hint Resolve locally_closed_open_t_abs : main.

--- a/proofs/system_f/opening_substitution.v
+++ b/proofs/system_f/opening_substitution.v
@@ -27,7 +27,7 @@ Proof.
   clean. outro i. induction t1; search.
 Qed.
 
-#[export] Hint Resolve tt_sub_intro : main.
+Hint Resolve tt_sub_intro : main.
 
 Theorem ee_sub_intro :
   forall e1 e2 i x,
@@ -37,7 +37,7 @@ Proof.
   induction e1; search.
 Qed.
 
-#[export] Hint Resolve ee_sub_intro : main.
+Hint Resolve ee_sub_intro : main.
 
 Theorem et_sub_intro :
   forall e i t x,
@@ -47,7 +47,7 @@ Proof.
   induction e; search; clean; rewrite tt_sub_intro with (x := x); search.
 Qed.
 
-#[export] Hint Resolve et_sub_intro : main.
+Hint Resolve et_sub_intro : main.
 
 (******************************************)
 (* Substitution distributes over opening. *)
@@ -64,7 +64,7 @@ Proof.
     apply t_local_closure_monotonic with (i1 := i); search.
 Qed.
 
-#[export] Hint Resolve tttt_sub_open : main.
+Hint Resolve tttt_sub_open : main.
 
 Theorem eeee_sub_open :
   forall e1 e2 e3 ie it x,
@@ -79,7 +79,7 @@ Proof.
     apply e_local_closure_monotonic with (ie1 := ie) (it1 := it); search.
 Qed.
 
-#[export] Hint Resolve eeee_sub_open : main.
+Hint Resolve eeee_sub_open : main.
 
 Theorem eeet_sub_open :
   forall e1 e2 ie it t x,
@@ -93,7 +93,7 @@ Proof.
     apply e_local_closure_monotonic with (ie1 := ie) (it1 := it); search.
 Qed.
 
-#[export] Hint Resolve eeet_sub_open : main.
+Hint Resolve eeet_sub_open : main.
 
 Theorem etee_sub_open :
   forall i e1 e2 t x,
@@ -105,7 +105,7 @@ Proof.
   apply t_local_closure_monotonic with (i1 := i); search.
 Qed.
 
-#[export] Hint Resolve etee_sub_open : main.
+Hint Resolve etee_sub_open : main.
 
 Theorem etet_sub_open :
   forall i e t1 t2 x,
@@ -117,4 +117,4 @@ Proof.
   apply t_local_closure_monotonic with (i1 := i); search.
 Qed.
 
-#[export] Hint Resolve etet_sub_open : main.
+Hint Resolve etet_sub_open : main.

--- a/proofs/system_f/preservation.v
+++ b/proofs/system_f/preservation.v
@@ -63,7 +63,7 @@ Proof.
     rewrite t_domain_concat in *. clean. search.
 Qed.
 
-#[export] Hint Resolve e_substitution_preserves_typing : main.
+Hint Resolve e_substitution_preserves_typing : main.
 
 Theorem t_substitution_preserves_typing :
   forall c1 c2 e t1 t2 x,
@@ -126,7 +126,7 @@ Proof.
     destruct H4; search.
 Qed.
 
-#[export] Hint Resolve t_substitution_preserves_typing : main.
+Hint Resolve t_substitution_preserves_typing : main.
 
 Theorem preservation :
   forall e1 e2 t,
@@ -148,4 +148,4 @@ Proof.
     replace c_empty with (c_concat c_empty (c_sub c_empty x t2)); esearch.
 Qed.
 
-#[export] Hint Resolve preservation : main.
+Hint Resolve preservation : main.

--- a/proofs/system_f/progress.v
+++ b/proofs/system_f/progress.v
@@ -32,4 +32,4 @@ Proof.
     + exists (e_t_app x t2). invert H. search.
 Qed.
 
-#[export] Hint Resolve progress : main.
+Hint Resolve progress : main.

--- a/proofs/system_f/semantics.v
+++ b/proofs/system_f/semantics.v
@@ -21,7 +21,7 @@ Inductive Value : Term -> Prop :=
   ELocallyClosed (e_t_abs e) 0 0 ->
   Value (e_t_abs e).
 
-#[export] Hint Constructors Value : main.
+Hint Constructors Value : main.
 
 Inductive Step : Term -> Term -> Prop :=
 | s_beta :
@@ -50,7 +50,7 @@ Inductive Step : Term -> Term -> Prop :=
   TLocallyClosed t 0 ->
   Step (e_t_app (e_t_abs e1) t) (et_open e1 0 t).
 
-#[export] Hint Constructors Step : main.
+Hint Constructors Step : main.
 
 Theorem StepRegularity :
   forall e1 e2,
@@ -64,7 +64,7 @@ Proof.
   - invert H; search.
 Qed.
 
-#[export] Hint Resolve StepRegularity : main.
+Hint Resolve StepRegularity : main.
 
 Inductive StepStar : Term -> Term -> Prop :=
 | ss_refl :
@@ -77,7 +77,7 @@ Inductive StepStar : Term -> Term -> Prop :=
   StepStar e2 e3 ->
   StepStar e1 e3.
 
-#[export] Hint Constructors StepStar : main.
+Hint Constructors StepStar : main.
 
 Theorem StepStarRegularity :
   forall e1 e2,
@@ -87,4 +87,4 @@ Proof.
   clean. induction H; search. pose proof (StepRegularity e1 e2). search.
 Qed.
 
-#[export] Hint Resolve StepStarRegularity : main.
+Hint Resolve StepStarRegularity : main.

--- a/proofs/system_f/soundness.v
+++ b/proofs/system_f/soundness.v
@@ -22,4 +22,4 @@ Proof.
   clean. induction H0; esearch.
 Qed.
 
-#[export] Hint Resolve soundness : main.
+Hint Resolve soundness : main.

--- a/proofs/system_f/substitution.v
+++ b/proofs/system_f/substitution.v
@@ -53,7 +53,7 @@ Proof.
   induction t1; search.
 Qed.
 
-#[export] Hint Resolve ttt_sub_bound : main.
+Hint Resolve ttt_sub_bound : main.
 
 Theorem eee_sub_bound :
   forall e1 e2 x,
@@ -63,7 +63,7 @@ Proof.
   induction e1; search.
 Qed.
 
-#[export] Hint Resolve eee_sub_bound : main.
+Hint Resolve eee_sub_bound : main.
 
 Theorem eet_sub_bound :
   forall e t x,
@@ -73,7 +73,7 @@ Proof.
   induction e; search; clean; f_equal; search; apply ttt_sub_bound; search.
 Qed.
 
-#[export] Hint Resolve eet_sub_bound : main.
+Hint Resolve eet_sub_bound : main.
 
 (*****************************************)
 (* Substitution preserves local closure. *)
@@ -90,7 +90,7 @@ Proof.
   apply t_local_closure_monotonic with (i1 := i); search.
 Qed.
 
-#[export] Hint Resolve tt_sub_locally_closed : main.
+Hint Resolve tt_sub_locally_closed : main.
 
 Theorem ee_sub_locally_closed :
   forall e1 e2 ie it x,
@@ -103,7 +103,7 @@ Proof.
     apply e_local_closure_monotonic with (ie1 := ie) (it1 := it); search.
 Qed.
 
-#[export] Hint Resolve ee_sub_locally_closed : main.
+Hint Resolve ee_sub_locally_closed : main.
 
 Theorem et_sub_locally_closed :
   forall e ie it t x,
@@ -116,7 +116,7 @@ Proof.
   apply t_local_closure_monotonic with (i1 := it); search.
 Qed.
 
-#[export] Hint Resolve et_sub_locally_closed : main.
+Hint Resolve et_sub_locally_closed : main.
 
 (************************************)
 (* Free variables of a substitution *)
@@ -163,7 +163,7 @@ Proof.
     ); search.
 Qed.
 
-#[export] Hint Resolve ttt_free_sub : main.
+Hint Resolve ttt_free_sub : main.
 
 Theorem eeee_free_sub :
   forall e1 e2 x,
@@ -180,7 +180,7 @@ Proof.
     ); search.
 Qed.
 
-#[export] Hint Resolve eeee_free_sub : main.
+Hint Resolve eeee_free_sub : main.
 
 Theorem eeet_free_sub :
   forall e t x,
@@ -189,7 +189,7 @@ Proof.
   clean. induction e; search.
 Qed.
 
-#[export] Hint Resolve eeet_free_sub : main.
+Hint Resolve eeet_free_sub : main.
 
 Theorem etee_free_sub :
   forall e1 e2 x,
@@ -204,7 +204,7 @@ Proof.
   - apply incl_tran with (m := et_free_vars e1 ++ t_free_vars t); search.
 Qed.
 
-#[export] Hint Resolve etee_free_sub : main.
+Hint Resolve etee_free_sub : main.
 
 Theorem etet_free_sub :
   forall e t x,
@@ -233,4 +233,4 @@ Proof.
     ); search.
 Qed.
 
-#[export] Hint Resolve etet_free_sub : main.
+Hint Resolve etet_free_sub : main.

--- a/proofs/system_f/typing.v
+++ b/proofs/system_f/typing.v
@@ -52,7 +52,7 @@ Inductive HasType : Context -> Term -> Ty -> Prop :=
   HasType c e (t_for_all t1) ->
   HasType c (e_t_app e t2) (tt_open t1 0 t2).
 
-#[export] Hint Constructors HasType : main.
+Hint Constructors HasType : main.
 
 (*****************************************)
 (* The regularity of the typing judgment *)
@@ -102,7 +102,7 @@ Proof.
       * unfold TWellFormed in H2. search.
 Qed.
 
-#[export] Hint Resolve typing_regularity : main.
+Hint Resolve typing_regularity : main.
 
 (*********************)
 (* Context weakening *)
@@ -155,4 +155,4 @@ Proof.
     assert (In a (t_domain c3) \/ In a (t_domain c1)); search.
 Qed.
 
-#[export] Hint Resolve context_weakening : main.
+Hint Resolve context_weakening : main.

--- a/proofs/type_theory/indices.v
+++ b/proofs/type_theory/indices.v
@@ -29,14 +29,14 @@ Inductive Exp1 : Set -> Type :=
 | add1 : Exp1 nat -> Exp1 nat -> Exp1 nat
 | less_than1 : Exp1 nat -> Exp1 nat -> Exp1 bool.
 
-#[export] Hint Constructors Exp1 : main.
+Hint Constructors Exp1 : main.
 
 Inductive Exp2 (a : Set) : Set :=
 | const2 : a -> Exp2 a
 | add2 : nat = a -> Exp2 nat -> Exp2 nat -> Exp2 a
 | less_than2 : bool = a -> Exp2 nat -> Exp2 nat -> Exp2 a.
 
-#[export] Hint Constructors Exp2 : main.
+Hint Constructors Exp2 : main.
 
 Fixpoint exp1_to_exp2 (a : Set) (e1 : Exp1 a) : Exp2 a :=
   match e1 with
@@ -66,7 +66,7 @@ Proof.
   induction e; search.
 Qed.
 
-#[export] Hint Resolve exp1_to_exp2_to_exp1 : main.
+Hint Resolve exp1_to_exp2_to_exp1 : main.
 
 Theorem exp2_to_exp1_to_exp2 :
   forall (a : Set) (e : Exp2 a), exp1_to_exp2 a (exp2_to_exp1 a e) = e.
@@ -75,7 +75,7 @@ Proof.
   induction e; search.
 Qed.
 
-#[export] Hint Resolve exp2_to_exp1_to_exp2 : main.
+Hint Resolve exp2_to_exp1_to_exp2 : main.
 
 (*
   Just for fun, we implement evaluators for both of the inductive definitions
@@ -113,7 +113,7 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve exp1_to_exp2_preserves_eval : main.
+Hint Resolve exp1_to_exp2_preserves_eval : main.
 
 Theorem exp2_to_exp1_preserves_eval :
   forall (a : Set) (e : Exp2 a), eval2 a e = eval1 a (exp2_to_exp1 a e).
@@ -126,4 +126,4 @@ Proof.
   search.
 Qed.
 
-#[export] Hint Resolve exp2_to_exp1_preserves_eval : main.
+Hint Resolve exp2_to_exp1_preserves_eval : main.

--- a/proofs/type_theory/reflection.v
+++ b/proofs/type_theory/reflection.v
@@ -25,8 +25,8 @@ Proof.
     + discriminate H0.
 Qed.
 
-#[export] Hint Resolve -> reflect_iff : main.
-#[export] Hint Resolve <- reflect_iff : main.
+Hint Resolve -> reflect_iff : main.
+Hint Resolve <- reflect_iff : main.
 
 Ltac reflect b :=
   let H1 := fresh "H" in
@@ -54,7 +54,7 @@ Inductive Even : nat -> Prop :=
 | even_zero : Even 0
 | even_ss : forall n : nat, Even n -> Even (S (S n)).
 
-#[export] Hint Constructors Even : main.
+Hint Constructors Even : main.
 
 Fixpoint is_even n :=
   match n with
@@ -94,7 +94,7 @@ Proof.
     + intros. destruct (H n). unfold P in H1. auto.
 Qed.
 
-#[export] Hint Resolve even_refl : main.
+Hint Resolve even_refl : main.
 
 (* A proof by reflection of `Even 1000` *)
 


### PR DESCRIPTION
Remove explicit `export` locality attributes in `Hint` commands now that the default is `export`.

**Status:** Ready

**Fixes:** N/A