### PR TITLE
Use Coq's `eq` instead of a custom identity type in the HoTT development

### DIFF
--- a/proofs/type_theory/homotopy_type_theory.v
+++ b/proofs/type_theory/homotopy_type_theory.v
@@ -16,15 +16,10 @@ Require Import Coq.Program.Basics.
 
 Definition U := Type.
 
-(* The identity type *)
-
-Inductive Path [X] (x : X) : X -> Type :=
-| refl : Path x x.
-
 (* Homotopy *)
 
 Definition Homotopy [X] [Y : X -> Type] (f g : forall x : X, Y x) :=
-  forall x, Path (f x) (g x).
+  forall x, f x = g x.
 
 (* Equivalence *)
 
@@ -35,24 +30,24 @@ Definition Equivalence [X Y] (f : X -> Y) :=
 (* Paths can be converted to equivalences. *)
 
 Definition idIsEquivalence X : Equivalence (@id X) := (
-  existT (fun g => Homotopy g _) _ (@refl _),
-  existT (fun g => Homotopy g _) _ (@refl _)
+  existT (fun g => Homotopy g _) _ (@eq_refl _),
+  existT (fun g => Homotopy g _) _ (@eq_refl _)
 ).
 
-Definition pathToEquivalence [X Y] (p : Path X Y) :
+Definition pathToEquivalence [X Y] (p : X = Y) :
   { f : X -> Y & Equivalence f } :=
-  match p in Path _ Z return { f : X -> Z & Equivalence f } with
-  | refl _ => existT _ _ (idIsEquivalence X)
+  match p in _ = Z return { f : X -> Z & Equivalence f } with
+  | eq_refl _ => existT _ _ (idIsEquivalence X)
   end.
 
 (* Paths between functions can be converted to homotopies. *)
 
 Definition pathToHomotopy [X] [Y : X -> Type]
-  (f g : forall x : X, Y x) (p : Path f g) :
+  (f g : forall x : X, Y x) (p : f = g) :
   Homotopy f g :=
   fun x =>
-    match p in Path _ h return Path (f x) (h x) with
-    | refl _ => refl _
+    match p in _ = h return f x = h x with
+    | eq_refl _ => eq_refl _
     end.
 
 (* Function extensionality *)
@@ -93,8 +88,8 @@ Definition weekendToBitIsEquivalence : Equivalence weekendToBit := (
     (
       fun x =>
         match x with
-        | Zero => refl _
-        | One => refl _
+        | Zero => eq_refl _
+        | One => eq_refl _
         end
     ),
   existT (fun g => Homotopy (g ∘ weekendToBit) id)
@@ -102,13 +97,13 @@ Definition weekendToBitIsEquivalence : Equivalence weekendToBit := (
     (
       fun x =>
         match x with
-        | Saturday => refl _
-        | Sunday => refl _
+        | Saturday => eq_refl _
+        | Sunday => eq_refl _
         end
     )
 ).
 
-Definition weekendToBitPath : Path Weekend Bit :=
+Definition weekendToBitPath : Weekend = Bit :=
   projT1
     (fst (univalence Weekend Bit))
     (existT _ weekendToBit weekendToBitIsEquivalence).
@@ -119,12 +114,12 @@ Definition invertWeekend x :=
   | Sunday => Saturday
   end.
 
-Definition invertBit : Bit -> Bit :=
-  match weekendToBitPath in Path _ Z return Z -> Z with
-  | refl _ => invertWeekend
-  end.
+Theorem invertWeekendInvolution x : invertWeekend (invertWeekend x) = x.
+Proof.
+  destruct x; auto.
+Qed.
 
-Definition weekendEqualsBit : Weekend = Bit :=
-  match weekendToBitPath in Path _ Z return Weekend = Z with
-  | refl _ => eq_refl
+Definition invertBit : Bit -> Bit :=
+  match weekendToBitPath in _ = Z return Z -> Z with
+  | eq_refl _ => invertWeekend
   end.


### PR DESCRIPTION
Use Coq's `eq` instead of a custom identity type in the HoTT development.

**Status:** Ready

**Fixes:** N/A