### PR TITLE
Bring back the CI badge with the new URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Proofs
 
+[![Build status](https://github.com/stepchowfun/proofs/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/stepchowfun/proofs/actions?query=branch%3Amain)
+
 This is my personal repository of formally verified mathematics, including results from category theory, type theory, domain theory, etc., and some original research. All the proofs are verified using the [Coq proof assistant](https://coq.inria.fr/).
 
 If you want to set up your own repository of formally verified mathematics, you can simply fork this repository and replace the contents of the [`proofs`](https://github.com/stepchowfun/proofs/tree/main/proofs)<!-- [dir:proofs] --> directory with your own proofs. Setting up a Coq project from scratch is not particularly straightforward, so this scaffolding can save you time.


### PR DESCRIPTION
Bring back the CI badge with the new URL scheme.

**Status:** Ready

**Fixes:** N/A